### PR TITLE
Add Block256 (GF(2^256)) tower extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Benchmarks for `Block128` SpMV with fixed degree 16 (typical for Brakedown/Biniu
 
 ```toml
 [dependencies]
-hekate-math = "0.5.0"
+hekate-math = "0.6.0"
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Hardware-accelerated binary tower fields for zero-knowledge proofs.
 
 `hekate-math` provides a high-performance, constant-time implementation of binary tower fields (𝔽(2^k))
 optimized for GKR-based provers, Sumcheck, and Binius protocols. The library implements a rigorous algebraic tower
-construction up to 𝔽(2^128), leveraging basis isomorphism to utilize native CPU hardware instructions:
+construction up to 𝔽(2^256), leveraging basis isomorphism to utilize native CPU hardware instructions:
 PMULL (ARMv8 NEON) and PCLMULQDQ (x86_64 AVX2).
 
 Designed for low-level cryptographic engineering, the crate is `no-std` compatible and defaults to constant-time
@@ -257,11 +257,13 @@ The construction follows a strict recursive data layout. Higher-order blocks are
 of two lower-order blocks (Low, High).
 
 ```plaintext
-              Block128 (GF(2^128))
-                /              \
-          Block64              Block64
-           /    \              /     \
-       Block32  Block32      ...     ...
+                    Block256 (GF(2^256))
+                    /              \
+              Block128              Block128 (GF(2^128))
+                /    \              /     \
+          Block64   Block64       ...     ...
+           /    \
+       Block32  Block32
         /    \
     Block16  Block16
      /    \
@@ -275,14 +277,15 @@ of two lower-order blocks (Low, High).
 The extension defines 𝔽(2^(2^(i+1))) ≅ 𝔽(2^(2^i))[v] / (v² + v + βᵢ),
 where βᵢ is the extension constant (`EXTENSION_TAU`) for that level.
 
-| Height | Field     | Implementation | Extension Constant (β)       | Arithmetic            |
-|:-------|:----------|:---------------|:-----------------------------|:----------------------|
-| h=0    | 𝔽₂       | `Bit`          | N/A                          | Boolean (XOR/AND)     |
-| h=3    | 𝔽(2^8)   | `Block8`       | *Base Field* (AES Poly)      | Recursive / Karatsuba |
-| h=4    | 𝔽(2^16)  | `Block16`      | 0x20 ∈ Block8                | Recursive / Karatsuba |
-| h=5    | 𝔽(2^32)  | `Block32`      | 0x2000 ∈ Block16             | Recursive / Karatsuba |
-| h=6    | 𝔽(2^64)  | `Block64`      | 0x20000000 ∈ Block32         | Recursive / Karatsuba |
-| h=7    | 𝔽(2^128) | `Block128`     | 0x2000000000000000 ∈ Block64 | Recursive / Karatsuba |
+| Height | Field     | Implementation | Extension Constant (β)                        | Arithmetic            |
+|:-------|:----------|:---------------|:----------------------------------------------|:----------------------|
+| h=0    | 𝔽₂       | `Bit`          | N/A                                           | Boolean (XOR/AND)     |
+| h=3    | 𝔽(2^8)   | `Block8`       | *Base Field* (AES Poly)                       | Recursive / Karatsuba |
+| h=4    | 𝔽(2^16)  | `Block16`      | 0x20 ∈ Block8                                 | Recursive / Karatsuba |
+| h=5    | 𝔽(2^32)  | `Block32`      | 0x2000 ∈ Block16                              | Recursive / Karatsuba |
+| h=6    | 𝔽(2^64)  | `Block64`      | 0x20000000 ∈ Block32                          | Recursive / Karatsuba |
+| h=7    | 𝔽(2^128) | `Block128`     | 0x2000000000000000 ∈ Block64                  | Recursive / Karatsuba |
+| h=8    | 𝔽(2^256) | `Block256`     | 0x20000000000000000000000000000000 ∈ Block128 | Recursive / Karatsuba |
 
 *Note: The tower is rooted at F(2^8) (AES Field) for hardware compatibility. Lower fields (Bit)
 are subfields embedded via isomorphism, making this a Hybrid Tower construction.*

--- a/README.md
+++ b/README.md
@@ -237,11 +237,11 @@ fn example_spmv() {
 The immediate engineering focus is establishing absolute
 hardware supremacy across both ARM and x86 backends.
 
-- [ ] **x86_64 Hardware Acceleration (Beta → Prod)**
+- **x86_64 Hardware Acceleration (Beta → Prod)**
     - Replace software fallbacks with hand-tuned assembly/intrinsics for AVX2 and PCLMULQDQ.
     - **Goal**: Path to x86_64 Supremacy.
 
-- [ ] **Formal Verification & Execution Path Auditing**
+- **Formal Verification & Execution Path Auditing**
     - Mathematical modeling of execution boundaries and DoS-resistant state transitions.
     - **Goal**: Enforce strict `Result` propagation across all public interfaces for
       enterprise-grade fault tolerance.

--- a/benches/basis_conversion.rs
+++ b/benches/basis_conversion.rs
@@ -19,10 +19,15 @@ use criterion::{
     BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use hekate_math::{
-    Bit, Block8, Block16, Block32, Block64, Block128, CanonicalSerialize, Flat, HardwareField,
-    PackableField, PackedFlat, TowerField,
+    Bit, Block8, Block16, Block32, Block64, Block128, Block256, CanonicalSerialize, Flat,
+    HardwareField, PackableField, PackedFlat, TowerField,
 };
 use rand::{RngExt, rng};
+
+fn rand_field<F: TowerField>(rng: &mut rand::rngs::ThreadRng) -> F {
+    let bytes: [u8; 32] = rng.random();
+    F::from_uniform_bytes(&bytes)
+}
 
 fn bench_basis_conversion(c: &mut Criterion) {
     let mut group = c.benchmark_group("basis_conversion");
@@ -37,6 +42,7 @@ fn bench_basis_conversion(c: &mut Criterion) {
     run_conversion_bench::<Block32>(&mut group, "Block32", size);
     run_conversion_bench::<Block64>(&mut group, "Block64", size);
     run_conversion_bench::<Block128>(&mut group, "Block128", size);
+    run_conversion_bench::<Block256>(&mut group, "Block256", size);
 
     group.finish();
 }
@@ -46,7 +52,8 @@ where
     F: HardwareField + TowerField + CanonicalSerialize,
 {
     let mut rng = rng();
-    let input: Vec<F> = (0..size).map(|_| F::from(rng.random::<u128>())).collect();
+
+    let input: Vec<F> = (0..size).map(|_| rand_field(&mut rng)).collect();
     let bytes_per_elem = input[0].serialized_size() as u64;
 
     group.throughput(Throughput::Bytes(size as u64 * bytes_per_elem));

--- a/benches/field_ops.rs
+++ b/benches/field_ops.rs
@@ -19,8 +19,15 @@ use core::hint::black_box;
 use criterion::{
     BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
-use hekate_math::{Bit, Block8, Block16, Block32, Block64, Block128, Flat, HardwareField};
+use hekate_math::{
+    Bit, Block8, Block16, Block32, Block64, Block128, Block256, Flat, HardwareField, TowerField,
+};
 use rand::{RngExt, rng};
+
+fn rand_field<F: TowerField>(rng: &mut rand::rngs::ThreadRng) -> F {
+    let bytes: [u8; 32] = rng.random();
+    F::from_uniform_bytes(&bytes)
+}
 
 fn bench_mul_latency(c: &mut Criterion) {
     let mut group = c.benchmark_group("field_ops/mul_latency");
@@ -31,6 +38,7 @@ fn bench_mul_latency(c: &mut Criterion) {
     run_mul_bench::<Block32>(&mut group, "Block32");
     run_mul_bench::<Block64>(&mut group, "Block64");
     run_mul_bench::<Block128>(&mut group, "Block128");
+    run_mul_bench::<Block256>(&mut group, "Block256");
 
     group.finish();
 }
@@ -42,8 +50,8 @@ where
     // Setup:
     // Generate random field elements
     let mut rng = rng();
-    let a: F = rng.random::<u128>().into();
-    let b: F = rng.random::<u128>().into();
+    let a: F = rand_field(&mut rng);
+    let b: F = rand_field(&mut rng);
 
     // 1. Baseline:
     // Tower Basis Multiplication (Recursive Karatsuba)
@@ -72,6 +80,7 @@ fn bench_square_latency(c: &mut Criterion) {
     run_square_bench::<Block32>(&mut group, "Block32");
     run_square_bench::<Block64>(&mut group, "Block64");
     run_square_bench::<Block128>(&mut group, "Block128");
+    run_square_bench::<Block256>(&mut group, "Block256");
 
     group.finish();
 }
@@ -82,7 +91,7 @@ where
 {
     // Setup
     let mut rng = rng();
-    let a: F = rng.random::<u128>().into();
+    let a: F = rand_field(&mut rng);
 
     // 1. Tower Basis Squaring
     group.bench_function(format!("{}/tower_basis", name), |bencher| {
@@ -105,6 +114,7 @@ fn bench_inv_latency(c: &mut Criterion) {
     run_inv_bench::<Block32>(&mut group, "Block32");
     run_inv_bench::<Block64>(&mut group, "Block64");
     run_inv_bench::<Block128>(&mut group, "Block128");
+    run_inv_bench::<Block256>(&mut group, "Block256");
 
     group.finish();
 }
@@ -120,7 +130,7 @@ where
         .map(|_| {
             let mut x;
             loop {
-                x = rng.random::<u128>().into();
+                x = rand_field(&mut rng);
                 if x != F::ZERO {
                     break;
                 }
@@ -166,6 +176,7 @@ fn bench_add_throughput(c: &mut Criterion) {
     run_add_bench::<Block32>(&mut group, "Block32");
     run_add_bench::<Block64>(&mut group, "Block64");
     run_add_bench::<Block128>(&mut group, "Block128");
+    run_add_bench::<Block256>(&mut group, "Block256");
 
     group.finish();
 }
@@ -180,8 +191,9 @@ where
     group.throughput(Throughput::Elements(size as u64));
 
     let mut rng = rng();
-    let a: Vec<F> = (0..size).map(|_| rng.random::<u128>().into()).collect();
-    let b: Vec<F> = (0..size).map(|_| rng.random::<u128>().into()).collect();
+
+    let a: Vec<F> = (0..size).map(|_| rand_field(&mut rng)).collect();
+    let b: Vec<F> = (0..size).map(|_| rand_field(&mut rng)).collect();
 
     let mut out = vec![F::ZERO; size];
 

--- a/benches/promote.rs
+++ b/benches/promote.rs
@@ -18,7 +18,8 @@
 use core::hint::black_box;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use hekate_math::{
-    Block8, Block16, Block32, Block64, Block128, Flat, FlatPromote, HardwareField, TowerField,
+    Block8, Block16, Block32, Block64, Block128, Block256, Flat, FlatPromote, HardwareField,
+    TowerField,
 };
 use rand::{RngExt, rng};
 
@@ -36,6 +37,7 @@ fn bench_promote_scalar(c: &mut Criterion) {
     let val16 = Block16(rng.random::<u16>()).to_hardware();
     let val32 = Block32(rng.random::<u32>()).to_hardware();
     let val64 = Block64(rng.random::<u64>()).to_hardware();
+    let val128 = Block128(rng.random::<u128>()).to_hardware();
 
     group.bench_function("Block8_to_Block128", |b| {
         b.iter(|| Block128::promote_flat(black_box(val8)))
@@ -51,6 +53,14 @@ fn bench_promote_scalar(c: &mut Criterion) {
 
     group.bench_function("Block64_to_Block128", |b| {
         b.iter(|| Block128::promote_flat(black_box(val64)))
+    });
+
+    group.bench_function("Block8_to_Block256", |b| {
+        b.iter(|| Block256::promote_flat(black_box(val8)))
+    });
+
+    group.bench_function("Block128_to_Block256", |b| {
+        b.iter(|| Block256::promote_flat(black_box(val128)))
     });
 
     group.finish();

--- a/src/towers/block128.rs
+++ b/src/towers/block128.rs
@@ -150,7 +150,7 @@ impl CanonicalSerialize for Block128 {
             return Err(());
         }
 
-        writer.copy_from_slice(&self.0.to_le_bytes());
+        writer[..16].copy_from_slice(&self.0.to_le_bytes());
 
         Ok(())
     }

--- a/src/towers/block16.rs
+++ b/src/towers/block16.rs
@@ -155,7 +155,7 @@ impl CanonicalSerialize for Block16 {
             return Err(());
         }
 
-        writer.copy_from_slice(&self.0.to_le_bytes());
+        writer[..2].copy_from_slice(&self.0.to_le_bytes());
 
         Ok(())
     }

--- a/src/towers/block256.rs
+++ b/src/towers/block256.rs
@@ -1,0 +1,983 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the hekate-math project.
+// Copyright (C) 2026 Andrei Kochergin <zeek@tuta.com>
+// Copyright (C) 2026 Oumuamua Labs. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! BLOCK 256 (GF(2^256))
+use crate::{Bit, Block8, Block16, Block32, Block64, Block128};
+use crate::{
+    CanonicalDeserialize, CanonicalSerialize, Flat, FlatPromote, HardwareField, PackableField,
+    PackedFlat, TowerField,
+};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+// Flat<Block256> = Flat<Block128>[y] / (y² + y + τ_flat).
+// τ_flat = to_hardware(Block128::EXTENSION_TAU).
+const TAU_FLAT: u128 = 0x66340c45203fe3685d08f8c248334a81;
+
+#[derive(Copy, Clone, Default, Debug, Eq, PartialEq, Serialize, Deserialize, Zeroize)]
+#[repr(C, align(32))]
+pub struct Block256(pub [u128; 2]); // [lo, hi]
+
+impl Block256 {
+    const TAU: Self = Block256([0, 0x2000_0000_0000_0000_0000_0000_0000_0000]);
+
+    pub fn new(lo: Block128, hi: Block128) -> Self {
+        Self([lo.0, hi.0])
+    }
+
+    #[inline(always)]
+    pub fn split(self) -> (Block128, Block128) {
+        (Block128(self.0[0]), Block128(self.0[1]))
+    }
+}
+
+impl TowerField for Block256 {
+    const BITS: usize = 256;
+    const ZERO: Self = Block256([0, 0]);
+    const ONE: Self = Block256([1, 0]);
+
+    const EXTENSION_TAU: Self = Self::TAU;
+
+    fn invert(&self) -> Self {
+        let (l, h) = self.split();
+        let h2 = h * h;
+        let l2 = l * l;
+        let hl = h * l;
+        let norm = (h2 * Block128::EXTENSION_TAU) + hl + l2;
+
+        let norm_inv = norm.invert();
+        let res_hi = h * norm_inv;
+        let res_lo = (h + l) * norm_inv;
+
+        Self::new(res_lo, res_hi)
+    }
+
+    fn from_uniform_bytes(bytes: &[u8; 32]) -> Self {
+        let mut lo_buf = [0u8; 16];
+        let mut hi_buf = [0u8; 16];
+
+        lo_buf.copy_from_slice(&bytes[0..16]);
+        hi_buf.copy_from_slice(&bytes[16..32]);
+
+        Self([u128::from_le_bytes(lo_buf), u128::from_le_bytes(hi_buf)])
+    }
+}
+
+impl Add for Block256 {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        Self([self.0[0] ^ rhs.0[0], self.0[1] ^ rhs.0[1]])
+    }
+}
+
+impl Sub for Block256 {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        self.add(rhs)
+    }
+}
+
+impl Mul for Block256 {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self {
+        let (a0, a1) = self.split();
+        let (b0, b1) = rhs.split();
+
+        let v0 = a0 * b0;
+        let v1 = a1 * b1;
+        let v_sum = (a0 + a1) * (b0 + b1);
+
+        let c_hi = v0 + v_sum;
+        let c_lo = v0 + (v1 * Block128::EXTENSION_TAU);
+
+        Self::new(c_lo, c_hi)
+    }
+}
+
+impl AddAssign for Block256 {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0[0] ^= rhs.0[0];
+        self.0[1] ^= rhs.0[1];
+    }
+}
+
+impl SubAssign for Block256 {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0[0] ^= rhs.0[0];
+        self.0[1] ^= rhs.0[1];
+    }
+}
+
+impl MulAssign for Block256 {
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl CanonicalSerialize for Block256 {
+    fn serialized_size(&self) -> usize {
+        32
+    }
+
+    fn serialize(&self, writer: &mut [u8]) -> Result<(), ()> {
+        if writer.len() < 32 {
+            return Err(());
+        }
+
+        writer[0..16].copy_from_slice(&self.0[0].to_le_bytes());
+        writer[16..32].copy_from_slice(&self.0[1].to_le_bytes());
+
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for Block256 {
+    fn deserialize(bytes: &[u8]) -> Result<Self, ()> {
+        if bytes.len() < 32 {
+            return Err(());
+        }
+
+        let mut lo_buf = [0u8; 16];
+        let mut hi_buf = [0u8; 16];
+
+        lo_buf.copy_from_slice(&bytes[0..16]);
+        hi_buf.copy_from_slice(&bytes[16..32]);
+
+        Ok(Self([
+            u128::from_le_bytes(lo_buf),
+            u128::from_le_bytes(hi_buf),
+        ]))
+    }
+}
+
+impl From<u8> for Block256 {
+    fn from(val: u8) -> Self {
+        Self([val as u128, 0])
+    }
+}
+
+impl From<u32> for Block256 {
+    #[inline]
+    fn from(val: u32) -> Self {
+        Self([val as u128, 0])
+    }
+}
+
+impl From<u64> for Block256 {
+    #[inline]
+    fn from(val: u64) -> Self {
+        Self([val as u128, 0])
+    }
+}
+
+impl From<u128> for Block256 {
+    #[inline]
+    fn from(val: u128) -> Self {
+        Self([val, 0])
+    }
+}
+
+impl From<Bit> for Block256 {
+    #[inline(always)]
+    fn from(val: Bit) -> Self {
+        Self([val.0 as u128, 0])
+    }
+}
+
+impl From<Block8> for Block256 {
+    #[inline(always)]
+    fn from(val: Block8) -> Self {
+        Self([val.0 as u128, 0])
+    }
+}
+
+impl From<Block16> for Block256 {
+    #[inline(always)]
+    fn from(val: Block16) -> Self {
+        Self([val.0 as u128, 0])
+    }
+}
+
+impl From<Block32> for Block256 {
+    #[inline(always)]
+    fn from(val: Block32) -> Self {
+        Self([val.0 as u128, 0])
+    }
+}
+
+impl From<Block64> for Block256 {
+    #[inline(always)]
+    fn from(val: Block64) -> Self {
+        Self([val.0 as u128, 0])
+    }
+}
+
+impl From<Block128> for Block256 {
+    #[inline(always)]
+    fn from(val: Block128) -> Self {
+        Self([val.0, 0])
+    }
+}
+
+// ===================================
+// PACKED BLOCK 256 (Width = 2)
+// ===================================
+
+pub const PACKED_WIDTH_256: usize = 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(C, align(64))]
+pub struct PackedBlock256(pub [Block256; PACKED_WIDTH_256]);
+
+impl PackedBlock256 {
+    #[inline(always)]
+    pub fn zero() -> Self {
+        Self([Block256::ZERO; PACKED_WIDTH_256])
+    }
+
+    #[inline(always)]
+    pub fn broadcast(val: Block256) -> Self {
+        Self([val; PACKED_WIDTH_256])
+    }
+}
+
+impl PackableField for Block256 {
+    type Packed = PackedBlock256;
+
+    const WIDTH: usize = PACKED_WIDTH_256;
+
+    #[inline(always)]
+    fn pack(chunk: &[Self]) -> Self::Packed {
+        assert!(
+            chunk.len() >= PACKED_WIDTH_256,
+            "PackableField::pack: input slice too short",
+        );
+
+        let mut arr = [Self::ZERO; PACKED_WIDTH_256];
+        arr.copy_from_slice(&chunk[..PACKED_WIDTH_256]);
+
+        PackedBlock256(arr)
+    }
+
+    #[inline(always)]
+    fn unpack(packed: Self::Packed, output: &mut [Self]) {
+        assert!(
+            output.len() >= PACKED_WIDTH_256,
+            "PackableField::unpack: output slice too short",
+        );
+
+        output[..PACKED_WIDTH_256].copy_from_slice(&packed.0);
+    }
+}
+
+impl Add for PackedBlock256 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self {
+        let mut res = [Block256::ZERO; PACKED_WIDTH_256];
+        for ((out, l), r) in res.iter_mut().zip(self.0.iter()).zip(rhs.0.iter()) {
+            *out = *l + *r;
+        }
+
+        Self(res)
+    }
+}
+
+impl AddAssign for PackedBlock256 {
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: Self) {
+        for (l, r) in self.0.iter_mut().zip(rhs.0.iter()) {
+            *l += *r;
+        }
+    }
+}
+
+impl Sub for PackedBlock256 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self {
+        self.add(rhs)
+    }
+}
+
+impl SubAssign for PackedBlock256 {
+    #[inline(always)]
+    fn sub_assign(&mut self, rhs: Self) {
+        self.add_assign(rhs);
+    }
+}
+
+impl Mul for PackedBlock256 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self {
+        let mut res = [Block256::ZERO; PACKED_WIDTH_256];
+        for ((out, l), r) in res.iter_mut().zip(self.0.iter()).zip(rhs.0.iter()) {
+            *out = *l * *r;
+        }
+
+        Self(res)
+    }
+}
+
+impl MulAssign for PackedBlock256 {
+    #[inline(always)]
+    fn mul_assign(&mut self, rhs: Self) {
+        for (l, r) in self.0.iter_mut().zip(rhs.0.iter()) {
+            *l *= *r;
+        }
+    }
+}
+
+impl Mul<Block256> for PackedBlock256 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Block256) -> Self {
+        let mut res = [Block256::ZERO; PACKED_WIDTH_256];
+        for (out, v) in res.iter_mut().zip(self.0.iter()) {
+            *out = *v * rhs;
+        }
+
+        Self(res)
+    }
+}
+
+impl MulAssign<Block256> for PackedBlock256 {
+    #[inline(always)]
+    fn mul_assign(&mut self, rhs: Block256) {
+        for v in self.0.iter_mut() {
+            *v *= rhs;
+        }
+    }
+}
+
+impl HardwareField for Block256 {
+    #[inline(always)]
+    fn to_hardware(self) -> Flat<Self> {
+        let (lo, hi) = self.split();
+        let flat_lo = lo.to_hardware().into_raw().0;
+        let flat_hi = hi.to_hardware().into_raw().0;
+
+        Flat::from_raw(Block256([flat_lo, flat_hi]))
+    }
+
+    #[inline(always)]
+    fn from_hardware(value: Flat<Self>) -> Self {
+        let raw = value.into_raw();
+        let lo = Block128::from_hardware(Flat::from_raw(Block128(raw.0[0])));
+        let hi = Block128::from_hardware(Flat::from_raw(Block128(raw.0[1])));
+
+        Self::new(lo, hi)
+    }
+
+    #[inline(always)]
+    fn add_hardware(lhs: Flat<Self>, rhs: Flat<Self>) -> Flat<Self> {
+        let l = lhs.into_raw();
+        let r = rhs.into_raw();
+
+        Flat::from_raw(Block256([l.0[0] ^ r.0[0], l.0[1] ^ r.0[1]]))
+    }
+
+    #[inline(always)]
+    fn add_hardware_packed(lhs: PackedFlat<Self>, rhs: PackedFlat<Self>) -> PackedFlat<Self> {
+        PackedFlat::from_raw(lhs.into_raw() + rhs.into_raw())
+    }
+
+    #[inline(always)]
+    fn mul_hardware(lhs: Flat<Self>, rhs: Flat<Self>) -> Flat<Self> {
+        let a_lo = Flat::from_raw(Block128(lhs.into_raw().0[0]));
+        let a_hi = Flat::from_raw(Block128(lhs.into_raw().0[1]));
+        let b_lo = Flat::from_raw(Block128(rhs.into_raw().0[0]));
+        let b_hi = Flat::from_raw(Block128(rhs.into_raw().0[1]));
+
+        let tau = Flat::from_raw(Block128(TAU_FLAT));
+
+        let v0 = Block128::mul_hardware(a_lo, b_lo);
+        let v1 = Block128::mul_hardware(a_hi, b_hi);
+
+        let a_sum = Block128::add_hardware(a_lo, a_hi);
+        let b_sum = Block128::add_hardware(b_lo, b_hi);
+        let v_sum = Block128::mul_hardware(a_sum, b_sum);
+
+        let c_hi = Block128::add_hardware(v0, v_sum);
+
+        let v1_tau = Block128::mul_hardware(v1, tau);
+        let c_lo = Block128::add_hardware(v0, v1_tau);
+
+        Flat::from_raw(Block256([c_lo.into_raw().0, c_hi.into_raw().0]))
+    }
+
+    #[inline(always)]
+    fn mul_hardware_packed(lhs: PackedFlat<Self>, rhs: PackedFlat<Self>) -> PackedFlat<Self> {
+        let lhs = lhs.into_raw().0;
+        let rhs = rhs.into_raw().0;
+
+        let mut res = [Block256::ZERO; PACKED_WIDTH_256];
+        for i in 0..PACKED_WIDTH_256 {
+            res[i] = Self::mul_hardware(Flat::from_raw(lhs[i]), Flat::from_raw(rhs[i])).into_raw();
+        }
+
+        PackedFlat::from_raw(PackedBlock256(res))
+    }
+
+    #[inline(always)]
+    fn mul_hardware_scalar_packed(lhs: PackedFlat<Self>, rhs: Flat<Self>) -> PackedFlat<Self> {
+        let broadcasted = PackedBlock256::broadcast(rhs.into_raw());
+        Self::mul_hardware_packed(lhs, PackedFlat::from_raw(broadcasted))
+    }
+
+    #[inline(always)]
+    fn tower_bit_from_hardware(value: Flat<Self>, bit_idx: usize) -> u8 {
+        if bit_idx < 128 {
+            Block128::tower_bit_from_hardware(
+                Flat::from_raw(Block128(value.into_raw().0[0])),
+                bit_idx,
+            )
+        } else {
+            Block128::tower_bit_from_hardware(
+                Flat::from_raw(Block128(value.into_raw().0[1])),
+                bit_idx - 128,
+            )
+        }
+    }
+}
+
+const PROMOTE_CHUNK: usize = 64;
+
+impl FlatPromote<Block8> for Block256 {
+    #[inline(always)]
+    fn promote_flat(val: Flat<Block8>) -> Flat<Self> {
+        let promoted = Block128::promote_flat(val);
+        Flat::from_raw(Block256([promoted.into_raw().0, 0]))
+    }
+
+    fn promote_flat_batch(input: &[Flat<Block8>], output: &mut [Flat<Self>]) {
+        promote_chunked(input, output);
+    }
+}
+
+impl FlatPromote<Block16> for Block256 {
+    #[inline(always)]
+    fn promote_flat(val: Flat<Block16>) -> Flat<Self> {
+        let promoted = Block128::promote_flat(val);
+        Flat::from_raw(Block256([promoted.into_raw().0, 0]))
+    }
+
+    fn promote_flat_batch(input: &[Flat<Block16>], output: &mut [Flat<Self>]) {
+        promote_chunked(input, output);
+    }
+}
+
+impl FlatPromote<Block32> for Block256 {
+    #[inline(always)]
+    fn promote_flat(val: Flat<Block32>) -> Flat<Self> {
+        let promoted = Block128::promote_flat(val);
+        Flat::from_raw(Block256([promoted.into_raw().0, 0]))
+    }
+
+    fn promote_flat_batch(input: &[Flat<Block32>], output: &mut [Flat<Self>]) {
+        promote_chunked(input, output);
+    }
+}
+
+impl FlatPromote<Block64> for Block256 {
+    #[inline(always)]
+    fn promote_flat(val: Flat<Block64>) -> Flat<Self> {
+        let promoted = Block128::promote_flat(val);
+        Flat::from_raw(Block256([promoted.into_raw().0, 0]))
+    }
+
+    fn promote_flat_batch(input: &[Flat<Block64>], output: &mut [Flat<Self>]) {
+        promote_chunked(input, output);
+    }
+}
+
+impl FlatPromote<Block128> for Block256 {
+    #[inline(always)]
+    fn promote_flat(val: Flat<Block128>) -> Flat<Self> {
+        Flat::from_raw(Block256([val.into_raw().0, 0]))
+    }
+
+    fn promote_flat_batch(input: &[Flat<Block128>], output: &mut [Flat<Self>]) {
+        let n = input.len().min(output.len());
+        for i in 0..n {
+            output[i] = Flat::from_raw(Block256([input[i].into_raw().0, 0]));
+        }
+    }
+}
+
+#[inline(always)]
+fn promote_chunked<FromF>(input: &[Flat<FromF>], output: &mut [Flat<Block256>])
+where
+    FromF: HardwareField,
+    Block128: FlatPromote<FromF>,
+{
+    let n = input.len().min(output.len());
+
+    let mut scratch = [Flat::from_raw(Block128::ZERO); PROMOTE_CHUNK];
+    let mut i = 0;
+
+    while i < n {
+        let len = (n - i).min(PROMOTE_CHUNK);
+        Block128::promote_flat_batch(&input[i..i + len], &mut scratch[..len]);
+
+        for j in 0..len {
+            output[i + j] = Flat::from_raw(Block256([scratch[j].into_raw().0, 0]));
+        }
+
+        i += len;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{RngExt, rng};
+
+    #[test]
+    fn tau_flat_matches_derived() {
+        let derived = Block128::EXTENSION_TAU.to_hardware().into_raw().0;
+        assert_eq!(
+            TAU_FLAT, derived,
+            "TAU_FLAT drifted from Block128::EXTENSION_TAU.to_hardware()",
+        );
+    }
+
+    // ==================================
+    // BASIC
+    // ==================================
+
+    #[test]
+    fn tower_constants() {
+        // Check that tau is propagated correctly
+        // For Block256, tau must be (0, EXTENSION_TAU) from Block128.
+        let tau256 = Block256::EXTENSION_TAU;
+        let (lo256, hi256) = tau256.split();
+        assert_eq!(lo256, Block128::ZERO);
+        assert_eq!(hi256, Block128::EXTENSION_TAU);
+    }
+
+    #[test]
+    fn add_truth() {
+        let zero = Block256::ZERO;
+        let one = Block256::ONE;
+
+        assert_eq!(zero + zero, zero);
+        assert_eq!(zero + one, one);
+        assert_eq!(one + zero, one);
+        assert_eq!(one + one, zero);
+    }
+
+    #[test]
+    fn mul_truth() {
+        let zero = Block256::ZERO;
+        let one = Block256::ONE;
+
+        assert_eq!(zero * zero, zero);
+        assert_eq!(zero * one, zero);
+        assert_eq!(one * one, one);
+    }
+
+    #[test]
+    fn add() {
+        // 5 ^ 3 = 6
+        // 101 ^ 011 = 110
+        assert_eq!(Block256([5, 0]) + Block256([3, 0]), Block256([6, 0]));
+    }
+
+    #[test]
+    fn mul_simple() {
+        // x^1 * x^1 = x^2 (2 * 2 = 4) inside the Block8 subfield
+        assert_eq!(
+            Block256::from(2u32) * Block256::from(2u32),
+            Block256::from(4u32)
+        );
+    }
+
+    #[test]
+    fn mul_overflow() {
+        // AES reduction: 0x57 * 0x83 = 0xC1 inside the Block8 subfield
+        assert_eq!(
+            Block256::from(0x57u32) * Block256::from(0x83u32),
+            Block256::from(0xC1u32)
+        );
+    }
+
+    #[test]
+    fn karatsuba_correctness() {
+        // Y = (hi=ONE, lo=ZERO). Y^2 = Y + tau_256.
+        // So the result must be:
+        // hi = Block128::ONE (the Y component),
+        // lo = Block128::EXTENSION_TAU (the tau component).
+        let y = Block256::new(Block128::ZERO, Block128::ONE);
+        let squared = y * y;
+
+        let (res_lo, res_hi) = squared.split();
+
+        assert_eq!(res_hi, Block128::ONE, "Y^2 should contain Y component");
+        assert_eq!(
+            res_lo,
+            Block128::EXTENSION_TAU,
+            "Y^2 should contain tau_256 component"
+        );
+    }
+
+    #[test]
+    fn security_zeroize() {
+        let mut secret_val = Block256([0xDEAD_BEEF_CAFE_BABE_u128, 0xFEED_FACE_BAAD_F00D_u128]);
+        assert_ne!(secret_val, Block256::ZERO);
+
+        secret_val.zeroize();
+
+        assert_eq!(secret_val, Block256::ZERO, "Memory was not wiped!");
+        assert_eq!(
+            secret_val.0,
+            [0u128, 0u128],
+            "Underlying memory leak detected"
+        );
+    }
+
+    #[test]
+    fn invert_zero() {
+        assert_eq!(
+            Block256::ZERO.invert(),
+            Block256::ZERO,
+            "invert(0) must return 0"
+        );
+    }
+
+    #[test]
+    fn inversion_random() {
+        let mut rng = rng();
+        for _ in 0..1000 {
+            let val = Block256([rng.random(), rng.random()]);
+
+            if val != Block256::ZERO {
+                let inv = val.invert();
+                let identity = val * inv;
+
+                assert_eq!(
+                    identity,
+                    Block256::ONE,
+                    "Inversion identity failed: a * a^-1 != 1"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tower_embedding() {
+        let mut rng = rng();
+        for _ in 0..100 {
+            let a = Block128(rng.random());
+            let b = Block128(rng.random());
+
+            // 1. Structure:
+            // Block128 -> Block256
+            let a_lifted: Block256 = a.into();
+            let (lo, hi) = a_lifted.split();
+
+            assert_eq!(lo, a, "Embedding structure failed: low part mismatch");
+            assert_eq!(
+                hi,
+                Block128::ZERO,
+                "Embedding structure failed: high part must be zero"
+            );
+
+            // 2. Addition Homomorphism
+            let sum_sub = a + b;
+            let sum_lifted: Block256 = sum_sub.into();
+            let sum_in_super = Block256::from(a) + Block256::from(b);
+
+            assert_eq!(sum_lifted, sum_in_super, "Homomorphism failed: add");
+
+            // 3. Multiplication Homomorphism
+            let prod_sub = a * b;
+            let prod_lifted: Block256 = prod_sub.into();
+            let prod_in_super = Block256::from(a) * Block256::from(b);
+
+            assert_eq!(prod_lifted, prod_in_super, "Homomorphism failed: mul");
+        }
+    }
+
+    // ==================================
+    // HARDWARE
+    // ==================================
+
+    #[test]
+    fn isomorphism_roundtrip() {
+        let mut rng = rng();
+        for _ in 0..1000 {
+            let val = Block256([rng.random::<u128>(), rng.random::<u128>()]);
+            assert_eq!(val.to_hardware().to_tower(), val);
+        }
+    }
+
+    #[test]
+    fn flat_mul_homomorphism() {
+        let mut rng = rng();
+        for _ in 0..1000 {
+            let a = Block256([rng.random(), rng.random()]);
+            let b = Block256([rng.random(), rng.random()]);
+
+            let expected_flat = (a * b).to_hardware();
+            let actual_flat = a.to_hardware() * b.to_hardware();
+
+            assert_eq!(
+                actual_flat, expected_flat,
+                "Block256 flat multiplication mismatch: (a*b)^H != a^H * b^H"
+            );
+        }
+    }
+
+    #[test]
+    fn packed_consistency() {
+        let mut rng = rng();
+        for _ in 0..100 {
+            let mut a_vals = [Block256::ZERO; PACKED_WIDTH_256];
+            let mut b_vals = [Block256::ZERO; PACKED_WIDTH_256];
+
+            for i in 0..PACKED_WIDTH_256 {
+                a_vals[i] = Block256([rng.random::<u128>(), rng.random::<u128>()]);
+                b_vals[i] = Block256([rng.random::<u128>(), rng.random::<u128>()]);
+            }
+
+            let a_flat_vals = a_vals.map(|x| x.to_hardware());
+            let b_flat_vals = b_vals.map(|x| x.to_hardware());
+            let a_packed = Flat::<Block256>::pack(&a_flat_vals);
+            let b_packed = Flat::<Block256>::pack(&b_flat_vals);
+
+            let add_res = Block256::add_hardware_packed(a_packed, b_packed);
+
+            let mut add_out = [Block256::ZERO.to_hardware(); PACKED_WIDTH_256];
+            Flat::<Block256>::unpack(add_res, &mut add_out);
+
+            for i in 0..PACKED_WIDTH_256 {
+                assert_eq!(
+                    add_out[i],
+                    (a_vals[i] + b_vals[i]).to_hardware(),
+                    "Block256 SIMD add mismatch at index {}",
+                    i
+                );
+            }
+
+            let mul_res = Block256::mul_hardware_packed(a_packed, b_packed);
+
+            let mut mul_out = [Block256::ZERO.to_hardware(); PACKED_WIDTH_256];
+            Flat::<Block256>::unpack(mul_res, &mut mul_out);
+
+            for i in 0..PACKED_WIDTH_256 {
+                let expected_flat = (a_vals[i] * b_vals[i]).to_hardware();
+                assert_eq!(
+                    mul_out[i], expected_flat,
+                    "Block256 SIMD mul mismatch at index {}",
+                    i
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tower_bit_from_hardware_matches_tower() {
+        let mut rng = rng();
+        for _ in 0..64 {
+            let val = Block256([rng.random::<u128>(), rng.random::<u128>()]);
+            let flat = val.to_hardware();
+
+            for bit in 0..Block256::BITS {
+                let expected = if bit < 128 {
+                    ((val.0[0] >> bit) & 1) as u8
+                } else {
+                    ((val.0[1] >> (bit - 128)) & 1) as u8
+                };
+
+                assert_eq!(
+                    Block256::tower_bit_from_hardware(flat, bit),
+                    expected,
+                    "tower_bit mismatch at bit {}",
+                    bit
+                );
+            }
+        }
+    }
+
+    // ==================================
+    // PROMOTE
+    // ==================================
+
+    #[test]
+    fn promote_flat_batch_matches_scalar_block8() {
+        let mut rng = rng();
+        let input: Vec<Flat<Block8>> = (0..200)
+            .map(|_| Block8(rng.random::<u8>()).to_hardware())
+            .collect();
+
+        let mut batch_out = vec![Flat::from_raw(Block256::ZERO); input.len()];
+        <Block256 as FlatPromote<Block8>>::promote_flat_batch(&input, &mut batch_out);
+
+        for i in 0..input.len() {
+            let scalar = <Block256 as FlatPromote<Block8>>::promote_flat(input[i]);
+            assert_eq!(
+                batch_out[i], scalar,
+                "Block8 batch/scalar mismatch at {}",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn promote_flat_batch_matches_scalar_block16() {
+        let mut rng = rng();
+        let input: Vec<Flat<Block16>> = (0..200)
+            .map(|_| Block16(rng.random::<u16>()).to_hardware())
+            .collect();
+
+        let mut batch_out = vec![Flat::from_raw(Block256::ZERO); input.len()];
+        <Block256 as FlatPromote<Block16>>::promote_flat_batch(&input, &mut batch_out);
+
+        for i in 0..input.len() {
+            let scalar = <Block256 as FlatPromote<Block16>>::promote_flat(input[i]);
+            assert_eq!(
+                batch_out[i], scalar,
+                "Block16 batch/scalar mismatch at {}",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn promote_flat_batch_matches_scalar_block32() {
+        let mut rng = rng();
+        let input: Vec<Flat<Block32>> = (0..200)
+            .map(|_| Block32(rng.random::<u32>()).to_hardware())
+            .collect();
+
+        let mut batch_out = vec![Flat::from_raw(Block256::ZERO); input.len()];
+        <Block256 as FlatPromote<Block32>>::promote_flat_batch(&input, &mut batch_out);
+
+        for i in 0..input.len() {
+            let scalar = <Block256 as FlatPromote<Block32>>::promote_flat(input[i]);
+            assert_eq!(
+                batch_out[i], scalar,
+                "Block32 batch/scalar mismatch at {}",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn promote_flat_batch_matches_scalar_block64() {
+        let mut rng = rng();
+        let input: Vec<Flat<Block64>> = (0..200)
+            .map(|_| Block64(rng.random::<u64>()).to_hardware())
+            .collect();
+
+        let mut batch_out = vec![Flat::from_raw(Block256::ZERO); input.len()];
+        <Block256 as FlatPromote<Block64>>::promote_flat_batch(&input, &mut batch_out);
+
+        for i in 0..input.len() {
+            let scalar = <Block256 as FlatPromote<Block64>>::promote_flat(input[i]);
+            assert_eq!(
+                batch_out[i], scalar,
+                "Block64 batch/scalar mismatch at {}",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn promote_flat_batch_matches_scalar_block128() {
+        let mut rng = rng();
+        let input: Vec<Flat<Block128>> = (0..200)
+            .map(|_| Block128(rng.random::<u128>()).to_hardware())
+            .collect();
+
+        let mut batch_out = vec![Flat::from_raw(Block256::ZERO); input.len()];
+        <Block256 as FlatPromote<Block128>>::promote_flat_batch(&input, &mut batch_out);
+
+        for i in 0..input.len() {
+            let scalar = <Block256 as FlatPromote<Block128>>::promote_flat(input[i]);
+            assert_eq!(
+                batch_out[i], scalar,
+                "Block128 batch/scalar mismatch at {}",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn promote_flat_batch_partial_slice() {
+        let mut rng = rng();
+        let input: Vec<Flat<Block8>> = (0..10)
+            .map(|_| Block8(rng.random::<u8>()).to_hardware())
+            .collect();
+
+        let mut out_short = vec![Flat::from_raw(Block256::ZERO); 5];
+        <Block256 as FlatPromote<Block8>>::promote_flat_batch(&input, &mut out_short);
+
+        for i in 0..5 {
+            let scalar = <Block256 as FlatPromote<Block8>>::promote_flat(input[i]);
+            assert_eq!(out_short[i], scalar);
+        }
+
+        let short_input = &input[..3];
+
+        let mut out_long = vec![Flat::from_raw(Block256::ZERO); 10];
+        <Block256 as FlatPromote<Block8>>::promote_flat_batch(short_input, &mut out_long);
+
+        for i in 0..3 {
+            let scalar = <Block256 as FlatPromote<Block8>>::promote_flat(short_input[i]);
+            assert_eq!(out_long[i], scalar);
+        }
+
+        for val in out_long.iter().skip(3) {
+            assert_eq!(*val, Flat::from_raw(Block256::ZERO));
+        }
+    }
+
+    #[test]
+    fn promote_flat_batch_across_chunk_boundary() {
+        let mut rng = rng();
+        // Exercise lengths straddling PROMOTE_CHUNK.
+        for &n in &[
+            PROMOTE_CHUNK - 1,
+            PROMOTE_CHUNK,
+            PROMOTE_CHUNK + 1,
+            PROMOTE_CHUNK * 2 + 3,
+        ] {
+            let input: Vec<Flat<Block8>> = (0..n)
+                .map(|_| Block8(rng.random::<u8>()).to_hardware())
+                .collect();
+
+            let mut batch_out = vec![Flat::from_raw(Block256::ZERO); n];
+            <Block256 as FlatPromote<Block8>>::promote_flat_batch(&input, &mut batch_out);
+
+            for i in 0..n {
+                let scalar = <Block256 as FlatPromote<Block8>>::promote_flat(input[i]);
+                assert_eq!(batch_out[i], scalar, "n={}, idx={}", n, i);
+            }
+        }
+    }
+}

--- a/src/towers/block32.rs
+++ b/src/towers/block32.rs
@@ -150,7 +150,7 @@ impl CanonicalSerialize for Block32 {
             return Err(());
         }
 
-        writer.copy_from_slice(&self.0.to_le_bytes());
+        writer[..4].copy_from_slice(&self.0.to_le_bytes());
 
         Ok(())
     }

--- a/src/towers/block64.rs
+++ b/src/towers/block64.rs
@@ -150,7 +150,7 @@ impl CanonicalSerialize for Block64 {
             return Err(());
         }
 
-        writer.copy_from_slice(&self.0.to_le_bytes());
+        writer[..8].copy_from_slice(&self.0.to_le_bytes());
 
         Ok(())
     }

--- a/src/towers/mod.rs
+++ b/src/towers/mod.rs
@@ -18,6 +18,7 @@
 mod bit;
 mod block128;
 mod block16;
+mod block256;
 mod block32;
 mod block64;
 mod block8;
@@ -28,3 +29,4 @@ pub use block16::*;
 pub use block32::*;
 pub use block64::*;
 pub use block128::*;
+pub use block256::*;

--- a/tests/algebraic_prop.rs
+++ b/tests/algebraic_prop.rs
@@ -15,7 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use hekate_math::{Bit, Block8, Block16, Block32, Block64, Block128, HardwareField, TowerField};
+use hekate_math::{
+    Bit, Block8, Block16, Block32, Block64, Block128, Block256, Flat, FlatPromote, HardwareField,
+    TowerField,
+};
 use proptest::prelude::*;
 
 // Strategy:
@@ -51,6 +54,10 @@ fn any_block32() -> impl Strategy<Value = Block32> {
 // Strategy: Generate any Block128 from a random u128
 fn any_block128() -> impl Strategy<Value = Block128> {
     any::<u128>().prop_map(Block128)
+}
+
+fn any_block256() -> impl Strategy<Value = Block256> {
+    (any::<u128>(), any::<u128>()).prop_map(|(lo, hi)| Block256([lo, hi]))
 }
 
 proptest! {
@@ -413,4 +420,161 @@ proptest! {
         // convert(to_hardware(a)) == a
         prop_assert_eq!(a.to_hardware().to_tower(), a);
     }
+
+    // ==================================
+    // Block256
+    // ==================================
+
+    #[test]
+    fn prop_block256_add_associativity(a in any_block256(), b in any_block256(), c in any_block256()) {
+        prop_assert_eq!((a + b) + c, a + (b + c));
+    }
+
+    #[test]
+    fn prop_block256_mul_associativity(a in any_block256(), b in any_block256(), c in any_block256()) {
+        prop_assert_eq!((a * b) * c, a * (b * c));
+    }
+
+    #[test]
+    fn prop_block256_distributivity(a in any_block256(), b in any_block256(), c in any_block256()) {
+        prop_assert_eq!(a * (b + c), a * b + a * c);
+    }
+
+    #[test]
+    fn prop_block256_add_identity(a in any_block256()) {
+        prop_assert_eq!(a + Block256::ZERO, a);
+        prop_assert_eq!(Block256::ZERO + a, a);
+    }
+
+    #[test]
+    fn prop_block256_mul_identity(a in any_block256()) {
+        prop_assert_eq!(a * Block256::ONE, a);
+        prop_assert_eq!(Block256::ONE * a, a);
+    }
+
+    #[test]
+    fn prop_block256_additive_inverse(a in any_block256()) {
+        prop_assert_eq!(a + a, Block256::ZERO);
+    }
+
+    #[test]
+    fn prop_block256_mul_annihilation(a in any_block256()) {
+        prop_assert_eq!(a * Block256::ZERO, Block256::ZERO);
+        prop_assert_eq!(Block256::ZERO * a, Block256::ZERO);
+    }
+
+    #[test]
+    fn prop_block256_commutativity(a in any_block256(), b in any_block256()) {
+        prop_assert_eq!(a * b, b * a);
+    }
+
+    #[test]
+    fn prop_block256_invert_roundtrip(a in any_block256()) {
+        if a != Block256::ZERO {
+            prop_assert_eq!(a * a.invert(), Block256::ONE);
+        }
+    }
+
+    #[test]
+    fn prop_block256_subfield_embedding_block128(a in any_block128(), b in any_block128()) {
+        // Arithmetic in Block256 restricted
+        // to embedded Block128 values must
+        // agree with Block128 arithmetic.
+        let a256 = Block256::from(a);
+        let b256 = Block256::from(b);
+
+        prop_assert_eq!((a256 + b256).split().0, a + b);
+        prop_assert_eq!((a256 + b256).split().1, Block128::ZERO);
+
+        prop_assert_eq!((a256 * b256).split().0, a * b);
+        prop_assert_eq!((a256 * b256).split().1, Block128::ZERO);
+    }
+
+    #[test]
+    fn prop_block256_hardware_iso_roundtrip(a in any_block256()) {
+        prop_assert_eq!(a.to_hardware().to_tower(), a);
+    }
+
+    #[test]
+    fn prop_block256_flat_roundtrip(lo in any::<u128>(), hi in any::<u128>()) {
+        let flat = Flat::from_raw(Block256([lo, hi]));
+        let tower = Block256::from_hardware(flat);
+        prop_assert_eq!(tower.to_hardware(), flat);
+    }
+
+    #[test]
+    fn prop_block256_mul_homomorphism(a in any_block256(), b in any_block256()) {
+        let tower_product = a * b;
+        let flat_product = Block256::mul_hardware(a.to_hardware(), b.to_hardware());
+        prop_assert_eq!(tower_product.to_hardware(), flat_product);
+    }
+
+    #[test]
+    fn prop_block256_add_homomorphism(a in any_block256(), b in any_block256()) {
+        let tower_sum = a + b;
+        let flat_sum = Block256::add_hardware(a.to_hardware(), b.to_hardware());
+        prop_assert_eq!(tower_sum.to_hardware(), flat_sum);
+    }
+
+    #[test]
+    fn prop_block256_promote_block8(val in any::<u8>().prop_map(Block8)) {
+        let promoted = <Block256 as FlatPromote<Block8>>::promote_flat(val.to_hardware());
+        let embedded = Block256::from(val).to_hardware();
+        prop_assert_eq!(promoted, embedded);
+    }
+
+    #[test]
+    fn prop_block256_promote_block16(val in any::<u16>().prop_map(Block16)) {
+        let promoted = <Block256 as FlatPromote<Block16>>::promote_flat(val.to_hardware());
+        let embedded = Block256::from(val).to_hardware();
+        prop_assert_eq!(promoted, embedded);
+    }
+
+    #[test]
+    fn prop_block256_promote_block32(val in any::<u32>().prop_map(Block32)) {
+        let promoted = <Block256 as FlatPromote<Block32>>::promote_flat(val.to_hardware());
+        let embedded = Block256::from(val).to_hardware();
+        prop_assert_eq!(promoted, embedded);
+    }
+
+    #[test]
+    fn prop_block256_promote_block64(val in any::<u64>().prop_map(Block64)) {
+        let promoted = <Block256 as FlatPromote<Block64>>::promote_flat(val.to_hardware());
+        let embedded = Block256::from(val).to_hardware();
+        prop_assert_eq!(promoted, embedded);
+    }
+
+    #[test]
+    fn prop_block256_promote_block128(val in any_block128()) {
+        let promoted = <Block256 as FlatPromote<Block128>>::promote_flat(val.to_hardware());
+        let embedded = Block256::from(val).to_hardware();
+        prop_assert_eq!(promoted, embedded);
+    }
+}
+
+// Tr_{GF(2^128)/GF(2)}(τ) = 1
+// verifies that v² + v + τ is irreducible,
+// validating the Block128 -> Block256 tower extension.
+#[test]
+fn block128_extension_tau_trace_is_one() {
+    let tau = Block128::EXTENSION_TAU;
+
+    let mut power = tau;
+    let mut trace = tau;
+
+    for _ in 1..128 {
+        power = power * power;
+        trace += power;
+    }
+
+    assert_eq!(
+        trace,
+        Block128::ONE,
+        "Tr(τ₂₅₆) must be 1 for irreducibility"
+    );
+}
+
+#[test]
+fn block256_zero_invert_is_zero() {
+    assert_eq!(Block256::ZERO.invert(), Block256::ZERO);
 }

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -16,8 +16,8 @@
 // limitations under the License.
 
 use hekate_math::{
-    Bit, Block8, Block16, Block32, Block64, Block128, CanonicalDeserialize, CanonicalSerialize,
-    TowerField,
+    Bit, Block8, Block16, Block32, Block64, Block128, Block256, CanonicalDeserialize,
+    CanonicalSerialize, TowerField,
 };
 use rand::{RngExt, rng};
 
@@ -169,6 +169,47 @@ fn block128_endianness() {
 }
 
 #[test]
+fn block256_endianness() {
+    let val = Block256::ONE;
+    let mut expected_bytes = vec![0u8; 32];
+    expected_bytes[0] = 1;
+
+    assert_eq!(
+        val.to_bytes(),
+        expected_bytes,
+        "Block256(1) must be Little Endian padded to 32 bytes"
+    );
+
+    let recovered = Block256::deserialize(&expected_bytes).expect("Deserialize failed");
+    assert_eq!(recovered, val);
+
+    let max_val = Block256([u128::MAX, u128::MAX]);
+    let max_bytes = vec![0xFFu8; 32];
+    assert_eq!(max_val.to_bytes(), max_bytes);
+
+    run_serialization_roundtrip(max_val);
+}
+
+#[test]
+fn block256_from_uniform_bytes() {
+    let bytes: [u8; 32] = [
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E,
+        0x1F, 0x20,
+    ];
+
+    let val = Block256::from_uniform_bytes(&bytes);
+    let serialized = val.to_bytes();
+    assert_eq!(&serialized[..], &bytes[..]);
+}
+
+#[test]
+fn block256_deserialize_too_short() {
+    let bytes = [0u8; 31];
+    assert!(Block256::deserialize(&bytes).is_err());
+}
+
+#[test]
 fn fuzz_all_blocks_roundtrip() {
     let mut rng = rng();
 
@@ -178,5 +219,6 @@ fn fuzz_all_blocks_roundtrip() {
         run_serialization_roundtrip(Block32(rng.random()));
         run_serialization_roundtrip(Block64(rng.random()));
         run_serialization_roundtrip(Block128(rng.random()));
+        run_serialization_roundtrip(Block256([rng.random(), rng.random()]));
     }
 }


### PR DESCRIPTION
# Add Block256 (GF(2^256)) tower extension

## Summary

Extends the binary tower to height 8 with `Block256 = Block128[v] / (v² + v + τ)`,
completing the tower up to 256-bit field elements. Enables downstream protocols
requiring a 256-bit soundness margin without switching field families.

## What's in

- **`Block256` field type**: `TowerField`, `HardwareField`, `PackableField`,
  `CanonicalSerialize`/`Deserialize`, `Zeroize`, and `FlatPromote` from every
  smaller block.
- **Dual-basis arithmetic**: Karatsuba in the tower basis; PMULL-accelerated
  multiplication in the flat basis via two levels of recursion through
  `Block128`.
- **Packed type**: `PackedBlock256` (width 2, 64-byte aligned, 512 bits per
  register).
- **Batch promotion**: 64-element chunked path that inherits the existing
  NEON `promote_batch_N_to_128` kernels for the subfield -> Block128 step.
- **Extension constant verified**: `τ_256 = Block128::EXTENSION_TAU` proved
  irreducible by an absolute-trace check `Tr_{GF(2^128)/GF(2)}(τ) = 1`.
  Flat-basis `TAU_FLAT` is compile-time pinned with a runtime drift guard.

## Also included

- **Bug fix.** `CanonicalSerialize::serialize` on `Block16/32/64/128` panicked
  on writer buffers strictly larger than the field size. Sliced to the exact
  prefix; contract now matches the trait docstring.
- **Bench coverage.** All five benchmarks (`basis_conversion`, `field_ops`,
  `promote`) now cover Block256. Random field sampling switched to
  `from_uniform_bytes` so the seed space matches the field size.
- **README.** Tower diagram and extension-constant table updated with h=8.

## No breaking changes

Purely additive at the public API level. Existing block types unchanged apart
from the serialize bugfix (no behavior change for correctly-sized buffers).