### PR TITLE
Enforce binary weight invariant in ByteSparseMatrix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hekate-math"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hekate-math"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Oumuamua Labs", "Andrei Kochergin <zeek@tuta.com>"]
 repository = "https://github.com/oumuamua-labs/hekate-math"

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Benchmarks for `Block128` SpMV with fixed degree 16 (typical for Brakedown/Biniu
 
 | Matrix Size   | Time (M3 Max) | Throughput   | Memory Bandwidth (est.) |
 |:--------------|:--------------|:-------------|:------------------------|
-| **64K Rows**  | ~284 µs       | 3.69 Gelem/s | ~59 GB/s                |
-| **256K Rows** | ~912 µs       | 4.60 Gelem/s | ~73 GB/s                |
-| **1M Rows**   | ~5.16 ms      | 3.25 Gelem/s | ~52 GB/s                |
+| **64K Rows**  | ~171 µs       | 6.14 Gelem/s | ~98 GB/s                |
+| **256K Rows** | ~628 µs       | 6.68 Gelem/s | ~107 GB/s               |
+| **1M Rows**   | ~5.17 ms      | 3.25 Gelem/s | ~52 GB/s                |
 
 ## Installation
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -130,6 +130,12 @@ impl<F: Copy + Sync> VectorSource<F> for [F] {
 /// Stores weights as `u8` to save memory.
 /// Can be applied to ANY field that
 /// implements `FlatPromote<Block8>`.
+///
+/// SOUNDNESS:
+/// weights must be binary (0 or 1).
+/// tower_bit is GF(2)-linear, not
+/// GF(2^k)-linear, non-binary weight
+/// break virtual packing commutativity.
 #[derive(Clone, Debug)]
 pub struct ByteSparseMatrix {
     rows: usize,
@@ -164,6 +170,10 @@ impl ByteSparseMatrix {
             col_indices.len(),
             expected_len,
             "Column indices vector length mismatch"
+        );
+        assert!(
+            weights.iter().all(|&w| w == 0 || w == 1),
+            "Virtual packing requires binary weights"
         );
 
         for &idx in &col_indices {
@@ -647,49 +657,48 @@ mod tests {
 
     #[test]
     fn byte_sparse_matrix_spmv() {
-        // Scenario: 2 Rows, 2 Cols, Degree 2
+        // 2 rows,
+        // 3 cols,
+        // degree 2,
+        // binary weights only.
+        let weights = vec![1u8, 1u8, 1u8, 1u8];
 
-        // Weights are u8 (bytes)
-        let v1 = 1u8;
-        let v2 = 2u8;
-        let v3 = 3u8;
-        let v4 = 4u8;
+        // Row 0:
+        // col 0 + col 2,
+        // Row 1:
+        // col 1 + col 0
+        let col_indices = vec![0, 2, 1, 0];
 
-        let weights = vec![v1, v2, v3, v4];
-        let col_indices = vec![0, 1, 1, 0]; // Row 0: (0, 1), Row 1: (1, 0)
+        let matrix = ByteSparseMatrix::new(2, 3, 2, weights, col_indices);
 
-        // Manual construction of ByteSparseMatrix
-        let matrix = ByteSparseMatrix::new(2, 2, 2, weights, col_indices);
-
-        // Vector x = [10, 100]
-        // IMPORTANT: SpMV expects inputs in HARDWARE Basis!
-        // We must convert our test inputs to hardware basis first.
         let x0_tower = b128(10);
         let x1_tower = b128(100);
+        let x2_tower = b128(255);
 
-        let x = vec![x0_tower.to_hardware(), x1_tower.to_hardware()];
+        let x = vec![
+            x0_tower.to_hardware(),
+            x1_tower.to_hardware(),
+            x2_tower.to_hardware(),
+        ];
 
-        // Calculate EXPECTED value using standard (Tower) arithmetic,
-        // then convert the result to Hardware basis for comparison.
-        //
-        // Row 0 logic: 1*x0 + 2*x1
-        let w1 = Block128::from(v1);
-        let w2 = Block128::from(v2);
-        let y0_tower = w1 * x0_tower + w2 * x1_tower;
+        // Row 0:
+        // 1*x0 + 1*x2 = x0 + x2 (XOR)
+        let y0_tower = x0_tower + x2_tower;
 
-        // Row 1 logic: 3*x1 + 4*x0
-        let w3 = Block128::from(v3);
-        let w4 = Block128::from(v4);
-        let y1_tower = w3 * x1_tower + w4 * x0_tower;
+        // Row 1:
+        // 1*x1 + 1*x0 = x1 + x0 (XOR)
+        let y1_tower = x1_tower + x0_tower;
 
-        // The result from matrix.spmv will be in Hardware basis.
         let expected = vec![y0_tower.to_hardware(), y1_tower.to_hardware()];
-
-        // Test
         let res = matrix.spmv(x.as_slice());
 
-        // Now comparing Hardware(res) == Hardware(expected)
         assert_eq!(res, expected, "Sequential SpMV failed (Basis Mismatch?)");
+    }
+
+    #[test]
+    #[should_panic(expected = "binary weights")]
+    fn rejects_non_binary_weights() {
+        ByteSparseMatrix::new(1, 2, 2, vec![1, 3], vec![0, 1]);
     }
 
     #[test]

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Block8, Flat, FlatPromote, HardwareField};
+use crate::{Flat, HardwareField};
 use aes::Aes256;
 use aes::cipher::{BlockCipherEncrypt, KeyInit};
 use alloc::vec::Vec;
@@ -129,7 +129,7 @@ impl<F: Copy + Sync> VectorSource<F> for [F] {
 /// A Field-Agnostic Sparse Matrix.
 /// Stores weights as `u8` to save memory.
 /// Can be applied to ANY field that
-/// implements `FlatPromote<Block8>`.
+/// implements `HardwareField`.
 ///
 /// SOUNDNESS:
 /// weights must be binary (0 or 1).
@@ -326,6 +326,11 @@ impl ByteSparseMatrix {
             col_indices.set_len(total_elems);
         }
 
+        assert!(
+            weights.iter().all(|&w| w == 0 || w == 1),
+            "Binary weight invariant violated in generate_random"
+        );
+
         Self {
             rows,
             cols,
@@ -360,13 +365,13 @@ impl ByteSparseMatrix {
         &self.col_indices
     }
 
-    /// Generic SpMV that promotes u8 weights to
-    /// Field F on the fly. Uses the FlatPromote
-    /// trait for max speed (partial lookups).
+    /// Binary SpMV:
+    /// weights are 0 or 1, so each
+    /// term is a conditional XOR.
     /// Accepts any source implementing `VectorSource`.
     pub fn spmv<F, V>(&self, x: &V) -> Vec<Flat<F>>
     where
-        F: HardwareField + FlatPromote<Block8>,
+        F: HardwareField,
         V: VectorSource<Flat<F>> + ?Sized,
     {
         assert_eq!(x.len(), self.cols);
@@ -402,11 +407,12 @@ impl ByteSparseMatrix {
         unsafe { assume_init_vec(y) }
     }
 
-    /// Process a chunk of rows with lookahead prefetching.
+    /// Process a chunk of rows
+    /// with lookahead prefetching.
     #[inline(always)]
     fn process_chunk<F, V>(&self, start_row: usize, out_chunk: &mut [MaybeUninit<Flat<F>>], x: &V)
     where
-        F: HardwareField + FlatPromote<Block8> + Default + Copy,
+        F: HardwareField + Default + Copy,
         V: VectorSource<Flat<F>> + ?Sized,
     {
         // Strategy:
@@ -440,23 +446,23 @@ impl ByteSparseMatrix {
             let mut acc = Flat::from_raw(F::ZERO);
             let mut j = 0;
 
+            // Binary weight invariant:
+            // w ∈ {0, 1}
             while j + B <= self.degree {
                 let mut col_idxs = [0usize; B];
-                let mut weights = [Flat::from_raw(F::ZERO); B];
-
                 unsafe {
-                    for k in 0..B {
-                        let curr = row_offset + j + k;
-                        col_idxs[k] = *self.col_indices.get_unchecked(curr) as usize;
-
-                        let w = *self.weights.get_unchecked(curr);
-                        weights[k] = F::promote_flat(Block8(w).to_hardware());
+                    for (k, slot) in col_idxs.iter_mut().enumerate() {
+                        *slot = *self.col_indices.get_unchecked(row_offset + j + k) as usize;
                     }
                 }
 
                 let values = x.get_batch::<B>(&col_idxs);
-                for k in 0..B {
-                    acc += weights[k] * values[k];
+                unsafe {
+                    for (k, &val) in values.iter().enumerate() {
+                        if *self.weights.get_unchecked(row_offset + j + k) != 0 {
+                            acc += val;
+                        }
+                    }
                 }
 
                 j += B;
@@ -465,12 +471,10 @@ impl ByteSparseMatrix {
             while j < self.degree {
                 unsafe {
                     let curr = row_offset + j;
-                    let w = *self.weights.get_unchecked(curr);
-                    let w_field = F::promote_flat(Block8(w).to_hardware());
-                    let col_idx = *self.col_indices.get_unchecked(curr) as usize;
-                    let val = x.get_at(col_idx);
-
-                    acc += w_field * val;
+                    if *self.weights.get_unchecked(curr) != 0 {
+                        let col_idx = *self.col_indices.get_unchecked(curr) as usize;
+                        acc += x.get_at(col_idx);
+                    }
                 }
 
                 j += 1;
@@ -657,9 +661,7 @@ mod tests {
 
     #[test]
     fn byte_sparse_matrix_spmv() {
-        // 2 rows,
-        // 3 cols,
-        // degree 2,
+        // 2 rows, 3 cols, degree 2,
         // binary weights only.
         let weights = vec![1u8, 1u8, 1u8, 1u8];
 
@@ -693,6 +695,35 @@ mod tests {
         let res = matrix.spmv(x.as_slice());
 
         assert_eq!(res, expected, "Sequential SpMV failed (Basis Mismatch?)");
+    }
+
+    #[test]
+    fn zero_weight_entries_contribute_nothing() {
+        // 2 rows, 3 cols, degree 3.
+        // Row 0:
+        // w=1 col=0,
+        // w=0 col=1,
+        // w=1 col=2
+        // Row 1:
+        // w=0 col=0,
+        // w=1 col=1,
+        // w=0 col=2
+        let weights = vec![1, 0, 1, 0, 1, 0];
+        let col_indices = vec![0, 1, 2, 0, 1, 2];
+        let matrix = ByteSparseMatrix::new(2, 3, 3, weights, col_indices);
+
+        let x0 = b128(0xA0);
+        let x1 = b128(0xB0);
+        let x2 = b128(0xC0);
+        let x = vec![x0.to_hardware(), x1.to_hardware(), x2.to_hardware()];
+
+        // Row 0:
+        // 1*x0 + 0*x1 + 1*x2 = x0 + x2
+        // Row 1:
+        // 0*x0 + 1*x1 + 0*x2 = x1
+        let expected = vec![(x0 + x2).to_hardware(), x1.to_hardware()];
+
+        assert_eq!(matrix.spmv(x.as_slice()), expected);
     }
 
     #[test]


### PR DESCRIPTION
Security audit finding: `tower_bit(SpMV(x)) = SpMV(tower_bit(x))` requires binary weights.
`ByteSparseMatrix::new()` accepted arbitrary `u8`, no enforcement.

### Changes

- `ByteSparseMatrix::new()`: assert all weights ∈ {0, 1}
- Struct doc: soundness invariant noted
- `byte_sparse_matrix_spmv` test: rewritten with binary weights
- `rejects_non_binary_weights` test: confirms constructor rejects weight > 1

### Context

`generate_random` already hardcodes `1u8`. Risk was through `new()`, manual construction
with non-binary weights would silently break virtual packing soundness in TensorPCS.

---

## Low-hanging fruit

Binary weight invariant enables a fundamental optimization: since every weight is 0 or 1,
`w * x` is either `ZERO` or `x`. The inner loop no longer needs `Block8 -> Flat<F>` promotion
or hardware-basis field multiplication — just conditional XOR.

Removed from hot path per element:
- `Block8(w).to_hardware()` (basis conversion)
- `F::promote_flat(...)` (CT bitslice lift 8→128, ~2.3ns CT / ~0.3ns table-math)
- `Flat<F>` field multiply (~1.1ns)

Replaced with: branch on public weight byte + XOR accumulate.

`FlatPromote<Block8>` trait bound removed from `spmv()` and `process_chunk()`. The public
API now requires only `F: HardwareField`.

### SpMV Benchmark Results (Apple M3 Max, aarch64)

**table-math feature (vs README baseline):**

| Matrix Size | Before | After | Delta |
|:------------|:-------|:------|:------|
| 64K rows | ~284 µs, 3.69 Gelem/s | ~171 µs, 6.14 Gelem/s | -39.8%, +66% throughput |
| 256K rows | ~912 µs, 4.60 Gelem/s | ~628 µs, 6.68 Gelem/s | -31.1%, +45% throughput |
| 1M rows | ~5.16 ms, 3.25 Gelem/s | ~5.17 ms, 3.25 Gelem/s | ~same (memory-bound) |

**CT default vs table-math gap collapse:**

| Matrix Size | CT default | table-math | Gap |
|:------------|:-----------|:-----------|:----|
| 64K rows | ~179 µs, 5.85 Gelem/s | ~171 µs, 6.14 Gelem/s | ~5% |
| 256K rows | ~688 µs, 6.10 Gelem/s | ~628 µs, 6.68 Gelem/s | ~9% |
| 1M rows | ~5.74 ms, 2.92 Gelem/s | ~5.17 ms, 3.25 Gelem/s | ~10% |

The `table-math` feature previously gave ~2.5x SpMV speedup over CT default because
`FlatPromote` was the bottleneck. With promotion eliminated, both backends converge
to the same XOR-dominated inner loop. The remaining gap is from non-SpMV code paths.