### PR TITLE
Additive FFT over GF(2^16) (Gao–Mateer, Cantor basis)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 .idea
 .DS_Store
+.claude
 fuzz-*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hekate-math"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hekate-math"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors = [
     "Oumuamua Labs <info@oumuamua.dev>",

--- a/README.md
+++ b/README.md
@@ -53,10 +53,8 @@ Efficiency of polynomial operations in 𝔽(2^128).
 | **Dense Eval (Tower)**    | 2²⁰ coeffs      | 91.93 ms    | 174 MiB/s      |
 | **Dense Eval (Hardware)** | 2²⁰ coeffs      | **8.34 ms** | **1.87 GiB/s** |
 | **Batch Eval (SIMD)**     | 256 × 16384     | 5.43 ms     | 772 Melem/s    |
-| **Additive FFT (scalar)** | 2⁹ pts · Block16   | 7.08 µs     | 72 Melem/s     |
-| **Additive FFT (packed)** | 2⁹ pts · ×8 lanes  | 8.22 µs     | 499 Melem/s    |
-| **Additive FFT (scalar)** | 2¹⁶ pts · Block16  | 1.31 ms     | 50 Melem/s     |
-| **Additive FFT (packed)** | 2¹⁶ pts · ×8 lanes | 3.16 ms     | 166 Melem/s    |
+| **Additive FFT (scalar)** | 2¹⁶ · Block16   | 1.31 ms     | 50 Melem/s     |
+| **Additive FFT (packed)** | 2¹⁶ · ×8 lanes  | 3.16 ms     | 166 Melem/s    |
 | **Interpolate MSM**       | 65536 points    | 77.12 µs    | 850 Melem/s    |
 | **MLE Evaluation**        | 20 variables    | 1.27 ms     | 822 Melem/s    |
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Benchmarks for `Block128` SpMV with fixed degree 16 (typical for Brakedown/Biniu
 
 ```toml
 [dependencies]
-hekate-math = "0.6.0"
+hekate-math = "0.7.0"
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Efficiency of polynomial operations in 𝔽(2^128).
 | **Dense Eval (Tower)**    | 2²⁰ coeffs      | 91.93 ms    | 174 MiB/s      |
 | **Dense Eval (Hardware)** | 2²⁰ coeffs      | **8.34 ms** | **1.87 GiB/s** |
 | **Batch Eval (SIMD)**     | 256 × 16384     | 5.43 ms     | 772 Melem/s    |
-| **FFT Layer (RAM)**       | 2²⁰ elements    | 909 µs      | 1.15 Gelem/s   |
-| **FFT Layer (L1)**        | 256 elements    | 241 ns      | 1.06 Gelem/s   |
+| **Additive FFT (scalar)** | 2⁹ pts · Block16  | 7.08 µs     | 72 Melem/s     |
+| **Additive FFT (packed)** | 2⁹ pts · ×8 lanes | 8.22 µs     | 499 Melem/s    |
 | **Interpolate MSM**       | 65536 points    | 77.12 µs    | 850 Melem/s    |
 | **MLE Evaluation**        | 20 variables    | 1.27 ms     | 822 Melem/s    |
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ Efficiency of polynomial operations in 𝔽(2^128).
 | **Dense Eval (Tower)**    | 2²⁰ coeffs      | 91.93 ms    | 174 MiB/s      |
 | **Dense Eval (Hardware)** | 2²⁰ coeffs      | **8.34 ms** | **1.87 GiB/s** |
 | **Batch Eval (SIMD)**     | 256 × 16384     | 5.43 ms     | 772 Melem/s    |
-| **Additive FFT (scalar)** | 2⁹ pts · Block16  | 7.08 µs     | 72 Melem/s     |
-| **Additive FFT (packed)** | 2⁹ pts · ×8 lanes | 8.22 µs     | 499 Melem/s    |
+| **Additive FFT (scalar)** | 2⁹ pts · Block16   | 7.08 µs     | 72 Melem/s     |
+| **Additive FFT (packed)** | 2⁹ pts · ×8 lanes  | 8.22 µs     | 499 Melem/s    |
+| **Additive FFT (scalar)** | 2¹⁶ pts · Block16  | 1.31 ms     | 50 Melem/s     |
+| **Additive FFT (packed)** | 2¹⁶ pts · ×8 lanes | 3.16 ms     | 166 Melem/s    |
 | **Interpolate MSM**       | 65536 points    | 77.12 µs    | 850 Melem/s    |
 | **MLE Evaluation**        | 20 variables    | 1.27 ms     | 822 Melem/s    |
 

--- a/benches/poly_arithmetic.rs
+++ b/benches/poly_arithmetic.rs
@@ -18,9 +18,12 @@
 use core::hint::black_box;
 use core::mem::size_of;
 use criterion::{
-    BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
+    BatchSize, BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main,
+    measurement::WallTime,
 };
-use hekate_math::{Block128, Flat, HardwareField, PackableField, PackedBlock128, PackedFlat};
+use hekate_math::{
+    AdditiveFft, Block16, Block128, Flat, HardwareField, PackableField, PackedBlock128, PackedFlat,
+};
 use rand::{RngExt, rng};
 use std::time::Duration;
 
@@ -39,17 +42,10 @@ fn bench_poly_arithmetic(c: &mut Criterion) {
     // 256 * 16384 = ~4.1M ops.
     bench_eval_batch_block128(&mut group, 1 << 8, 1 << 14);
 
-    // 3. FFT Additive (Mock/Butterfly)
-    // Scenario A:
-    // RAM Bound (Large size, large stride)
-    // 1M elements, Stride 1024 (jumps around memory)
-    bench_fft_additive::<Block128>(&mut group, "Block128/ram_bound", 1 << 20, 1024);
-
-    // Scenario B:
-    // L1 Bound (Small size, contiguous)
-    // 256 elements, Stride 1 (packed).
-    // Shows peak compute power.
-    bench_fft_additive::<Block128>(&mut group, "Block128/l1_bound", 1 << 8, 1);
+    // 3. Additive FFT (Gao–Mateer, Block16).
+    // Profile A (n=512) and field-max (n=65536).
+    bench_fft_additive(&mut group, 9);
+    bench_fft_additive(&mut group, 16);
 
     // 4. Interpolate (Lagrange Subset)
     // MSM-like workload
@@ -172,54 +168,48 @@ fn bench_eval_batch_block128(
     );
 }
 
-// 3. Additive FFT (Mock Butterfly)
-fn bench_fft_additive<F>(
-    group: &mut BenchmarkGroup<WallTime>,
-    name: &str,
-    size: usize,
-    stride: usize,
-) where
-    F: HardwareField,
-{
+// 3. Additive FFT (Gao–Mateer, Block16)
+fn bench_fft_additive(group: &mut BenchmarkGroup<WallTime>, log_n: u32) {
+    let n = 1usize << log_n;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
     let mut rng = rng();
-    let mut data: Vec<Flat<F>> = (0..size)
-        .map(|_| F::from(rng.random::<u128>()).to_hardware())
+
+    let scalar_src: Vec<Flat<Block16>> = (0..n)
+        .map(|_| Block16::from(rng.random::<u16>()).to_hardware())
         .collect();
-    let twiddle = F::from(rng.random::<u128>()).to_hardware();
 
-    group.throughput(Throughput::Elements(size as u64));
-    group.bench_function(
-        format!("{}/fft_layer_{}_stride_{}", name, size, stride),
-        |bencher| {
-            bencher.iter(|| {
-                let mut i = 0;
-                while i < size {
-                    for j in 0..stride {
-                        if i + j + stride >= size {
-                            break;
-                        }
-
-                        // Unsafe get for max speed
-                        let u = unsafe { *data.get_unchecked(i + j) };
-                        let v = unsafe { *data.get_unchecked(i + j + stride) };
-
-                        // Butterfly operations
-                        let sum = u + v;
-                        let twisted = u + v * twiddle;
-
-                        unsafe {
-                            *data.get_unchecked_mut(i + j) = sum;
-                            *data.get_unchecked_mut(i + j + stride) = twisted;
-                        }
-                    }
-
-                    i += 2 * stride;
-                }
-
+    group.throughput(Throughput::Elements(n as u64));
+    group.bench_function(format!("Block16/fft_forward_scalar_{}", n), |bencher| {
+        bencher.iter_batched_ref(
+            || scalar_src.clone(),
+            |data| {
+                fft.forward_scalar(data).unwrap();
                 black_box(&data[0]);
-            })
-        },
-    );
+            },
+            BatchSize::LargeInput,
+        )
+    });
+
+    let packed_src: Vec<PackedFlat<Block16>> = (0..n)
+        .map(|_| {
+            let lanes: [Flat<Block16>; 8] =
+                core::array::from_fn(|_| Block16::from(rng.random::<u16>()).to_hardware());
+            Flat::<Block16>::pack(&lanes)
+        })
+        .collect();
+
+    group.throughput(Throughput::Elements((n * 8) as u64));
+    group.bench_function(format!("Block16/fft_forward_packed_{}x8", n), |bencher| {
+        bencher.iter_batched_ref(
+            || packed_src.clone(),
+            |data| {
+                fft.forward(data).unwrap();
+                black_box(&data[0]);
+            },
+            BatchSize::LargeInput,
+        )
+    });
 }
 
 // 4. Interpolate (Linear Combination subset)

--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,12 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
+// Mirror Block8::EXTENSION_TAU and constants::POLY_8/16;
+// write_algebra_extras_16 pins them at build time.
+const POLY_8: u8 = 0x1b;
+const POLY_16: u16 = 0x2b;
+const EXTENSION_TAU_8: u8 = 0x20;
+
 // === 8 BIT CONSTANTS ===
 // Generator 8:
 // Block8(27)
@@ -844,6 +850,272 @@ impl_write_nibble_promote_tables_to_128!(write_nibble_promote_16_to_128, u16, 4,
 impl_write_nibble_promote_tables_to_128!(write_nibble_promote_32_to_128, u32, 8, apply_32);
 impl_write_nibble_promote_tables_to_128!(write_nibble_promote_64_to_128, u64, 16, apply_64);
 
+// ==========================================
+// 9. ALGEBRAIC EXTRAS (Block16, GF(2^16))
+// ==========================================
+//
+// Block16 = Block8[X]/(X^2 + X + 0x20) over the
+// AES field (0x1b). Trace and the Artin-Schreier
+// operator L(x) = x^2 + x reduce to squaring, so
+// tower squaring is the only field op needed here.
+
+fn gf8_mul(mut a: u8, mut b: u8) -> u8 {
+    let mut res = 0u8;
+    let mut i = 0;
+
+    while i < 8 {
+        if b & 1 == 1 {
+            res ^= a;
+        }
+
+        let carry = a & 0x80;
+
+        a <<= 1;
+
+        if carry != 0 {
+            a ^= POLY_8;
+        }
+
+        b >>= 1;
+        i += 1;
+    }
+
+    res
+}
+
+fn sq16_tower(a: u16) -> u16 {
+    let lo = (a & 0x00ff) as u8;
+    let hi = (a >> 8) as u8;
+
+    let lo2 = gf8_mul(lo, lo);
+    let hi2 = gf8_mul(hi, hi);
+    let new_lo = lo2 ^ gf8_mul(hi2, EXTENSION_TAU_8);
+
+    ((hi2 as u16) << 8) | (new_lo as u16)
+}
+
+fn flat_sq_16(a: u16) -> u16 {
+    let mut acc = 0u32;
+
+    for i in 0..16 {
+        if (a >> i) & 1 == 1 {
+            acc ^= 1u32 << (2 * i);
+        }
+    }
+
+    for i in (16..32).rev() {
+        if (acc >> i) & 1 == 1 {
+            acc ^= (1u32 << i) ^ ((POLY_16 as u32) << (i - 16));
+        }
+    }
+
+    acc as u16
+}
+
+fn trace_of_16(x: u16) -> u16 {
+    let mut acc = 0u16;
+    let mut p = x;
+    let mut i = 0;
+
+    while i < 16 {
+        acc ^= p;
+        p = sq16_tower(p);
+        i += 1;
+    }
+
+    acc
+}
+
+// cols[k] and the result are column-image form:
+// column k is the image of basis vector e_k.
+fn gf2_invert_16(cols: &[u16; 16]) -> [u16; 16] {
+    let mut rows = [0u16; 16];
+    let mut inv = [0u16; 16];
+
+    for (i, slot) in inv.iter_mut().enumerate() {
+        *slot = 1 << i;
+    }
+
+    for (i, row) in rows.iter_mut().enumerate() {
+        for (k, &col) in cols.iter().enumerate() {
+            *row |= ((col >> i) & 1) << k;
+        }
+    }
+
+    for col in 0..16 {
+        let mut piv = col;
+        while piv < 16 && (rows[piv] >> col) & 1 == 0 {
+            piv += 1;
+        }
+
+        assert!(
+            piv < 16,
+            "Artin-Schreier operator is singular: field constants are inconsistent"
+        );
+
+        rows.swap(col, piv);
+        inv.swap(col, piv);
+
+        for r in 0..16 {
+            if r != col && (rows[r] >> col) & 1 == 1 {
+                rows[r] ^= rows[col];
+                inv[r] ^= inv[col];
+            }
+        }
+    }
+
+    let mut out = [0u16; 16];
+    for (k, slot) in out.iter_mut().enumerate() {
+        for (i, &v) in inv.iter().enumerate() {
+            *slot |= ((v >> k) & 1) << i;
+        }
+    }
+
+    out
+}
+
+fn vanish_build(i: usize, x: u16) -> u16 {
+    let mut t = x;
+    for _ in 0..i {
+        t = sq16_tower(t) ^ t;
+    }
+
+    t
+}
+
+fn gf2_rank_16(vals: &[u16; 16]) -> usize {
+    let mut piv = [0u16; 16];
+    let mut rank = 0;
+
+    for &v in vals.iter() {
+        let mut x = v;
+        while x != 0 {
+            let b = x.trailing_zeros() as usize;
+            if piv[b] == 0 {
+                piv[b] = x;
+                rank += 1;
+
+                break;
+            }
+
+            x ^= piv[b];
+        }
+    }
+
+    rank
+}
+
+fn write_algebra_extras_16(file: &mut File) {
+    // FIPS-197 §4.2 worked example pins POLY_8.
+    assert_eq!(gf8_mul(0x57, 0x83), 0xc1, "gf8_mul is not the AES field");
+
+    let mut trace_mask = 0u16;
+    for k in 0..16 {
+        if trace_of_16(1 << k) == 1 {
+            trace_mask |= 1 << k;
+        }
+    }
+
+    // L(x) = x^2 + x has kernel {0, 1}, so it is not
+    // invertible. Lift to L~(x) = L(x) + (bit0 x)*d with
+    // d outside the trace-zero image; then L~^-1 on the
+    // trace-zero subspace solves x^2 + x = c (Tr c = 0).
+    assert_ne!(
+        trace_mask, 0,
+        "trace functional is identically zero: field is broken"
+    );
+
+    let d = 1u16 << trace_mask.trailing_zeros();
+
+    let mut l_tilde = [0u16; 16];
+    for (k, slot) in l_tilde.iter_mut().enumerate() {
+        let l_k = sq16_tower(1 << k) ^ (1u16 << k);
+        *slot = l_k ^ if k == 0 { d } else { 0 };
+    }
+
+    let solve_basis = gf2_invert_16(&l_tilde);
+
+    // Build-time proof: trace laws + solvability.
+    let mut trace_zero = 0u32;
+    for x in 0u16..=u16::MAX {
+        let t = trace_of_16(x);
+        assert!(t <= 1, "trace escaped GF(2)");
+
+        let parity = ((x & trace_mask).count_ones() & 1) as u16;
+        assert_eq!(parity, t, "TRACE_MASK_16 does not reproduce the trace");
+
+        let via_basis = apply_16(
+            flat_sq_16(apply_16(x, &TOWER_TO_FLAT_16)),
+            &FLAT_TO_TOWER_16,
+        );
+        assert_eq!(
+            sq16_tower(x),
+            via_basis,
+            "tower squaring disagrees with the change-of-basis oracle: \
+             EXTENSION_TAU_8/POLY_8/POLY_16 inconsistent with the basis matrices"
+        );
+
+        if t == 0 {
+            trace_zero += 1;
+
+            let root = apply_16(x, &solve_basis);
+            assert_eq!(
+                sq16_tower(root) ^ root,
+                x,
+                "SOLVE_QUADRATIC_BASIS_16 fails the round-trip x^2 + x = c"
+            );
+        }
+    }
+
+    assert_eq!(trace_of_16(1), 0, "Tr(1) must vanish in GF(2^16)");
+    assert_eq!(trace_zero, 32768, "trace functional is unbalanced");
+
+    writeln!(file, "pub const TRACE_MASK_16: u16 = 0x{trace_mask:04x};\n").unwrap();
+    write_raw_16(file, "SOLVE_QUADRATIC_BASIS_16", &solve_basis);
+
+    // Cantor basis:
+    // β_0 = 1,
+    // β_i solves x^2 + x = β_{i-1}.
+    let mut cantor_tower = [0u16; 16];
+    cantor_tower[0] = 1;
+
+    for i in 1..16 {
+        cantor_tower[i] = apply_16(cantor_tower[i - 1], &solve_basis);
+    }
+
+    // V10 self-check:
+    // independence, β_0 = 1, σ(β_i) = β_{i-1},
+    // s_i(β_i) = 1,
+    // Tr(β_i) = 0 for i < 15 and Tr(β_15) = 1.
+    assert_eq!(
+        gf2_rank_16(&cantor_tower),
+        16,
+        "Cantor basis is GF(2)-dependent"
+    );
+    assert_eq!(cantor_tower[0], 1, "beta_0 must be 1");
+
+    for i in 0..16 {
+        assert_eq!(vanish_build(i, cantor_tower[i]), 1, "s_i(beta_i) != 1");
+
+        let tr = (cantor_tower[i] & trace_mask).count_ones() & 1;
+        if i < 15 {
+            assert_eq!(tr, 0, "Tr(beta_i) must vanish for i < 15");
+        } else {
+            assert_eq!(tr, 1, "Tr(beta_15) must be 1");
+        }
+
+        if i >= 1 {
+            assert_eq!(
+                sq16_tower(cantor_tower[i]) ^ cantor_tower[i],
+                cantor_tower[i - 1],
+                "Cantor chain broken: sigma(beta_i) != beta_(i-1)"
+            );
+        }
+    }
+
+    write_raw_16(file, "CANTOR_BASIS_TOWER_16", &cantor_tower);
+}
+
 fn main() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("generated_constants.rs");
@@ -852,8 +1124,8 @@ fn main() {
 
     writeln!(file, "// AUTO-GENERATED BY build.rs").unwrap();
 
-    writeln!(file, "pub const POLY_8: u8 = 0x1b;").unwrap();
-    writeln!(file, "pub const POLY_16: u16 = 0x002b;").unwrap();
+    writeln!(file, "pub const POLY_8: u8 = 0x{POLY_8:02x};").unwrap();
+    writeln!(file, "pub const POLY_16: u16 = 0x{POLY_16:04x};").unwrap();
     writeln!(file, "pub const POLY_32: u32 = 0x0000008d;").unwrap();
     writeln!(file, "pub const POLY_64: u64 = 0x000000000000001b;").unwrap();
     writeln!(
@@ -882,6 +1154,8 @@ fn main() {
     );
     write_raw_16(&mut file, "RAW_FLAT_TO_TOWER_16", &FLAT_TO_TOWER_16);
     write_raw_16(&mut file, "RAW_TOWER_TO_FLAT_16", &TOWER_TO_FLAT_16);
+
+    write_algebra_extras_16(&mut file);
 
     // 32 bit
     write_table_32(&mut file, "FLAT_TO_TOWER_32", &FLAT_TO_TOWER_32);

--- a/src/algebra.rs
+++ b/src/algebra.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the hekate-math project.
+// Copyright (C) 2026 Andrei Kochergin <andrei@oumuamua.dev>
+// Copyright (C) 2026 Oumuamua Labs <info@oumuamua.dev>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Binary-field algebraic extras.
+
+use crate::{Bit, TowerField};
+
+/// Binary-field operations beyond core `TowerField`:
+/// Frobenius, absolute trace, and the Artin-Schreier
+/// solver underpinning the Cantor/FFT substrate.
+pub trait BinaryFieldExtras: TowerField {
+    fn square(&self) -> Self {
+        *self * *self
+    }
+
+    /// `x^(2^k)`. `k` is taken mod the field degree
+    /// (`x^(2^BITS) = x`), so any `k` is valid.
+    fn frobenius(&self, k: u32) -> Self {
+        let reps = (k % Self::BITS as u32) as usize;
+
+        let mut acc = *self;
+        for _ in 0..reps {
+            acc = acc.square();
+        }
+
+        acc
+    }
+
+    /// Absolute trace `Tr_{F/GF(2)}(x) = Σ x^(2^i)`,
+    /// always 0 or 1.
+    fn trace(&self) -> Bit {
+        let mut acc = Self::ZERO;
+        let mut p = *self;
+
+        for _ in 0..Self::BITS {
+            acc += p;
+            p = p.square();
+        }
+
+        Bit((acc == Self::ONE) as u8)
+    }
+
+    /// A root of `x^2 + x = c`, or `None` iff
+    /// `Tr(c) != 0` (then it has no solution).
+    /// When solvable, the roots are the result and
+    /// `result + ONE`. The value path is constant-time;
+    /// only the `Some`/`None` choice reveals `Tr(c)`.
+    fn solve_quadratic(c: Self) -> Option<Self>;
+}

--- a/src/fft/additive.rs
+++ b/src/fft/additive.rs
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the hekate-math project.
+// Copyright (C) 2026 Andrei Kochergin <andrei@oumuamua.dev>
+// Copyright (C) 2026 Oumuamua Labs <info@oumuamua.dev>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Gao–Mateer additive FFT (Cantor basis).
+
+use crate::{BinaryFieldExtras, Flat, HardwareField, PackedFlat};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+/// Error returned by the additive-FFT transforms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FftError {
+    BadLength { expected: usize, got: usize },
+}
+
+impl core::fmt::Display for FftError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            FftError::BadLength { expected, got } => {
+                write!(f, "AdditiveFft data length {got}, expected {expected}")
+            }
+        }
+    }
+}
+
+impl core::error::Error for FftError {}
+
+/// In-place additive FFT over a 2^log_n subspace of a binary
+/// tower field. Transforms return `Err(FftError::BadLength)`
+/// unless data.len() == 2^log_n; on success the buffer
+/// is overwritten in place.
+pub struct AdditiveFft<F> {
+    log_n: u32,
+
+    // twiddles[t] = Σ_{bit i of t} β_{i+1},
+    // flat basis.
+    twiddles: Box<[Flat<F>]>,
+}
+
+impl<F: BinaryFieldExtras + HardwareField> AdditiveFft<F> {
+    /// Derives the Cantor basis (via solve_quadratic) and
+    /// the twiddle schedule for transform size 2^log_n.
+    /// This one-time allocation is the only heap use;
+    /// the transforms are in-place.
+    ///
+    /// # Panics
+    /// If log_n is not in 1..=min(F::BITS, 63),
+    /// or F admits no Cantor basis of that size.
+    pub fn new(log_n: u32) -> Self {
+        assert!(
+            (1..=F::BITS).contains(&(log_n as usize)) && log_n < usize::BITS,
+            "AdditiveFft: log_n must be in 1..=min(F::BITS, 63)"
+        );
+
+        let dim = log_n as usize;
+
+        let mut lift: Vec<Flat<F>> = Vec::with_capacity(dim - 1);
+        let mut beta = F::ONE;
+
+        for _ in 1..dim {
+            beta = F::solve_quadratic(beta).expect("field admits no Cantor basis of this size");
+            lift.push(beta.to_hardware());
+        }
+
+        let half = 1usize << (log_n - 1);
+
+        let mut twiddles = Vec::with_capacity(half);
+        for t in 0..half {
+            let mut acc = Flat::from_raw(F::ZERO);
+            let mut bits = t;
+
+            while bits != 0 {
+                let j = bits.trailing_zeros() as usize;
+                acc += lift[j];
+                bits &= bits - 1;
+            }
+
+            twiddles.push(acc);
+        }
+
+        Self {
+            log_n,
+            twiddles: twiddles.into_boxed_slice(),
+        }
+    }
+
+    /// Forward: novel-basis coefficients to evaluations.
+    pub fn forward_scalar(&self, data: &mut [Flat<F>]) -> Result<(), FftError> {
+        self.forward_coset_scalar(data, Flat::from_raw(F::ZERO))
+    }
+
+    /// Inverse: evaluations to novel-basis coefficients.
+    pub fn inverse_scalar(&self, data: &mut [Flat<F>]) -> Result<(), FftError> {
+        self.inverse_coset_scalar(data, Flat::from_raw(F::ZERO))
+    }
+
+    /// Forward over the coset offset + W_log_n.
+    pub fn forward_coset_scalar(
+        &self,
+        data: &mut [Flat<F>],
+        offset: Flat<F>,
+    ) -> Result<(), FftError> {
+        self.check_len(data.len())?;
+        self.fwd_scalar(data, 0, 1, self.log_n, offset);
+
+        Ok(())
+    }
+
+    /// Inverse over the coset offset + W_log_n.
+    pub fn inverse_coset_scalar(
+        &self,
+        data: &mut [Flat<F>],
+        offset: Flat<F>,
+    ) -> Result<(), FftError> {
+        self.check_len(data.len())?;
+        self.inv_scalar(data, 0, 1, self.log_n, offset);
+
+        Ok(())
+    }
+
+    /// Forward, F::WIDTH column-lanes per element in lockstep.
+    pub fn forward(&self, data: &mut [PackedFlat<F>]) -> Result<(), FftError> {
+        self.forward_coset(data, Flat::from_raw(F::ZERO))
+    }
+
+    /// Inverse, F::WIDTH column-lanes per element in lockstep.
+    pub fn inverse(&self, data: &mut [PackedFlat<F>]) -> Result<(), FftError> {
+        self.inverse_coset(data, Flat::from_raw(F::ZERO))
+    }
+
+    /// Packed forward over the coset offset + W_log_n.
+    pub fn forward_coset(
+        &self,
+        data: &mut [PackedFlat<F>],
+        offset: Flat<F>,
+    ) -> Result<(), FftError> {
+        self.check_len(data.len())?;
+        self.fwd_packed(data, 0, 1, self.log_n, offset);
+
+        Ok(())
+    }
+
+    /// Packed inverse over the coset offset + W_log_n.
+    pub fn inverse_coset(
+        &self,
+        data: &mut [PackedFlat<F>],
+        offset: Flat<F>,
+    ) -> Result<(), FftError> {
+        self.check_len(data.len())?;
+        self.inv_packed(data, 0, 1, self.log_n, offset);
+
+        Ok(())
+    }
+
+    fn check_len(&self, got: usize) -> Result<(), FftError> {
+        let expected = 1usize << self.log_n;
+
+        if got != expected {
+            return Err(FftError::BadLength { expected, got });
+        }
+
+        Ok(())
+    }
+
+    // Decimation-in-time radix-2 butterfly (Gao–Mateer).
+    // σ(x) = x^2 + x maps W_d two-to-one onto W_{d-1}; the
+    // pair (2t, 2t+1) differs by β_0 = 1, so the twiddle is
+    // coset + twiddles[t] and the odd output is just + q.
+    // Strided recursion keeps the output in natural order.
+    fn fwd_scalar(&self, data: &mut [Flat<F>], off: usize, stride: usize, d: u32, coset: Flat<F>) {
+        if d == 0 {
+            return;
+        }
+
+        let half = 1usize << (d - 1);
+        let child = coset * coset + coset;
+
+        self.fwd_scalar(data, off, stride * 2, d - 1, child);
+        self.fwd_scalar(data, off + stride, stride * 2, d - 1, child);
+
+        for t in 0..half {
+            let tw = coset + self.twiddles[t];
+            let i0 = off + 2 * t * stride;
+            let i1 = i0 + stride;
+
+            let p = data[i0];
+            let q = data[i1];
+            let lo = p + tw * q;
+
+            data[i0] = lo;
+            data[i1] = lo + q;
+        }
+    }
+
+    // Inverse butterfly:
+    // q = o0 + o1, then p = o0 + tw*q.
+    // No β^-1 needed (pairs differ by β_0 = 1).
+    fn inv_scalar(&self, data: &mut [Flat<F>], off: usize, stride: usize, d: u32, coset: Flat<F>) {
+        if d == 0 {
+            return;
+        }
+
+        let half = 1usize << (d - 1);
+        let child = coset * coset + coset;
+
+        for t in 0..half {
+            let tw = coset + self.twiddles[t];
+            let i0 = off + 2 * t * stride;
+            let i1 = i0 + stride;
+
+            let o0 = data[i0];
+            let o1 = data[i1];
+            let q = o0 + o1;
+
+            data[i0] = o0 + tw * q;
+            data[i1] = q;
+        }
+
+        self.inv_scalar(data, off, stride * 2, d - 1, child);
+        self.inv_scalar(data, off + stride, stride * 2, d - 1, child);
+    }
+
+    fn fwd_packed(
+        &self,
+        data: &mut [PackedFlat<F>],
+        off: usize,
+        stride: usize,
+        d: u32,
+        coset: Flat<F>,
+    ) {
+        if d == 0 {
+            return;
+        }
+
+        let half = 1usize << (d - 1);
+        let child = coset * coset + coset;
+
+        self.fwd_packed(data, off, stride * 2, d - 1, child);
+        self.fwd_packed(data, off + stride, stride * 2, d - 1, child);
+
+        for t in 0..half {
+            let tw = coset + self.twiddles[t];
+            let i0 = off + 2 * t * stride;
+            let i1 = i0 + stride;
+
+            let p = data[i0];
+            let q = data[i1];
+            let lo = F::add_hardware_packed(p, F::mul_hardware_scalar_packed(q, tw));
+
+            data[i0] = lo;
+            data[i1] = F::add_hardware_packed(lo, q);
+        }
+    }
+
+    fn inv_packed(
+        &self,
+        data: &mut [PackedFlat<F>],
+        off: usize,
+        stride: usize,
+        d: u32,
+        coset: Flat<F>,
+    ) {
+        if d == 0 {
+            return;
+        }
+
+        let half = 1usize << (d - 1);
+        let child = coset * coset + coset;
+
+        for t in 0..half {
+            let tw = coset + self.twiddles[t];
+            let i0 = off + 2 * t * stride;
+            let i1 = i0 + stride;
+
+            let o0 = data[i0];
+            let o1 = data[i1];
+            let q = F::add_hardware_packed(o0, o1);
+
+            data[i0] = F::add_hardware_packed(o0, F::mul_hardware_scalar_packed(q, tw));
+            data[i1] = q;
+        }
+
+        self.inv_packed(data, off, stride * 2, d - 1, child);
+        self.inv_packed(data, off + stride, stride * 2, d - 1, child);
+    }
+}

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the hekate-math project.
+// Copyright (C) 2026 Andrei Kochergin <andrei@oumuamua.dev>
+// Copyright (C) 2026 Oumuamua Labs <info@oumuamua.dev>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Additive FFT over GF(2^N) (Cantor basis).
+
+mod additive;
+
+pub use additive::{AdditiveFft, FftError};
+
+use crate::{BinaryFieldExtras, Bit, Block16, TowerField, constants};
+
+/// The GF(2)-basis {β_0, …, β_15} of GF(2^16) with
+/// β_0 = 1 and β_{i-1} = β_i^2 + β_i (Cantor 1989).
+/// Baked at build time; this is a typed view over it.
+pub struct CantorBasis;
+
+impl CantorBasis {
+    pub const DIM: usize = 16;
+
+    pub fn beta_tower(i: usize) -> Block16 {
+        Block16(constants::CANTOR_BASIS_TOWER_16[i])
+    }
+
+    /// Verifies the baked basis against live field arithmetic:
+    /// independence, β_0 = 1, σ(β_i) = β_{i-1},
+    /// s_i(β_i) = 1, and the trace pattern.
+    pub fn self_check() -> bool {
+        if Self::beta_tower(0) != Block16::ONE {
+            return false;
+        }
+
+        let mut piv = [0u16; 16];
+        let mut rank = 0;
+
+        for i in 0..Self::DIM {
+            let b = Self::beta_tower(i);
+
+            if vanish_eval(i, b) != Block16::ONE {
+                return false;
+            }
+
+            if (b.trace() == Bit(1)) != (i == Self::DIM - 1) {
+                return false;
+            }
+
+            if i >= 1 && b.square() + b != Self::beta_tower(i - 1) {
+                return false;
+            }
+
+            let mut x = b.0;
+            while x != 0 {
+                let p = x.trailing_zeros() as usize;
+
+                if piv[p] == 0 {
+                    piv[p] = x;
+                    rank += 1;
+                    break;
+                }
+
+                x ^= piv[p];
+            }
+        }
+
+        rank == Self::DIM
+    }
+}
+
+/// s_i(x): the GF(2)-linear vanishing polynomial of
+/// W_i = span(β_0..β_{i-1}). Equals the i-fold
+/// composition of σ(t) = t^2 + t; deg s_i = 2^i.
+pub fn vanish_eval<F: BinaryFieldExtras>(i: usize, x: F) -> F {
+    let mut t = x;
+    for _ in 0..i {
+        t = t.square() + t;
+    }
+
+    t
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // This file is part of the hekate-math project.
 // Copyright (C) 2026 Andrei Kochergin <andrei@oumuamua.dev>
-// Copyright (C) 2026 Oumuamua Labs <info@oumuamua.dev>. All rights reserved.
+// Copyright (C) 2026 Oumuamua Labs <info@oumuamua.dev>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 
 extern crate alloc;
 
+mod algebra;
 mod field;
 mod towers;
 
@@ -26,8 +27,11 @@ mod constants;
 mod hardware;
 mod packable;
 
+pub mod fft;
 pub mod matrix;
 
+pub use algebra::BinaryFieldExtras;
+pub use fft::{AdditiveFft, CantorBasis, FftError};
 pub use field::*;
 pub use hardware::{Flat, FlatPromote, HardwareField};
 pub use packable::{PackableField, PackedFlat};

--- a/src/towers/block16.rs
+++ b/src/towers/block16.rs
@@ -19,8 +19,8 @@
 use crate::towers::bit::Bit;
 use crate::towers::block8::Block8;
 use crate::{
-    CanonicalDeserialize, CanonicalSerialize, Flat, FlatPromote, HardwareField, PackableField,
-    PackedFlat, TowerField, constants,
+    BinaryFieldExtras, CanonicalDeserialize, CanonicalSerialize, Flat, FlatPromote, HardwareField,
+    PackableField, PackedFlat, TowerField, constants,
 };
 use core::ops::{Add, AddAssign, BitXor, BitXorAssign, Mul, MulAssign, Sub, SubAssign};
 use serde::{Deserialize, Serialize};
@@ -462,8 +462,19 @@ impl HardwareField for Block16 {
 
     #[inline(always)]
     fn mul_hardware_scalar_packed(lhs: PackedFlat<Self>, rhs: Flat<Self>) -> PackedFlat<Self> {
-        let broadcasted = PackedBlock16([rhs.into_raw(); PACKED_WIDTH_16]);
-        Self::mul_hardware_packed(lhs, PackedFlat::from_raw(broadcasted))
+        #[cfg(target_arch = "aarch64")]
+        {
+            PackedFlat::from_raw(neon::mul_flat_scalar_packed_16(
+                lhs.into_raw(),
+                rhs.into_raw(),
+            ))
+        }
+
+        #[cfg(not(target_arch = "aarch64"))]
+        {
+            let broadcasted = PackedBlock16([rhs.into_raw(); PACKED_WIDTH_16]);
+            Self::mul_hardware_packed(lhs, PackedFlat::from_raw(broadcasted))
+        }
     }
 
     #[inline(always)]
@@ -507,6 +518,39 @@ impl FlatPromote<Block8> for Block16 {
     }
 }
 
+// ===================================
+// Binary Field Extras
+// ===================================
+
+impl BinaryFieldExtras for Block16 {
+    #[inline(always)]
+    fn square(&self) -> Self {
+        // char 2:
+        // (lo + hi·X)^2 = lo^2 + hi^2·X^2,
+        // no cross term.
+        let (lo, hi) = self.split();
+        let hi2 = hi.square();
+
+        Self::new(lo.square() + hi2 * Block8::EXTENSION_TAU, hi2)
+    }
+
+    #[inline(always)]
+    fn trace(&self) -> Bit {
+        Bit(((self.0 & constants::TRACE_MASK_16).count_ones() & 1) as u8)
+    }
+
+    #[inline(always)]
+    fn solve_quadratic(c: Self) -> Option<Self> {
+        match c.trace() {
+            Bit(0) => Some(Block16(map_ct_16(
+                c.0,
+                &constants::SOLVE_QUADRATIC_BASIS_16,
+            ))),
+            _ => None,
+        }
+    }
+}
+
 // ===========================================
 // UTILS
 // ===========================================
@@ -536,7 +580,6 @@ pub fn apply_matrix_16(val: Block16, table: &[u16; 512]) -> Block16 {
     Block16(res)
 }
 
-#[cfg(not(feature = "table-math"))]
 #[inline(always)]
 fn map_ct_16(x: u16, basis: &[u16; 16]) -> u16 {
     let mut acc = 0u16;
@@ -545,6 +588,7 @@ fn map_ct_16(x: u16, basis: &[u16; 16]) -> u16 {
     while i < 16 {
         let bit = (x >> i) & 1;
         let mask = 0u16.wrapping_sub(bit);
+
         acc ^= basis[i] & mask;
         i += 1;
     }
@@ -561,6 +605,9 @@ mod neon {
     use super::*;
     use core::arch::aarch64::*;
     use core::mem::transmute;
+
+    // Shifts 5,3,1,0 in reduce_packed_16 encode R = POLY_16 (0x2b)
+    const _: () = assert!(constants::POLY_16 == 0x2b, "packed fold hardcodes R = 0x2b");
 
     #[inline(always)]
     pub fn add_packed_16(lhs: PackedBlock16, rhs: PackedBlock16) -> PackedBlock16 {
@@ -614,22 +661,104 @@ mod neon {
         }
     }
 
-    /// Vectorized multiplication
-    /// for Block16 (8 elements at once).
-    /// Uses Vector Karatsuba +
-    /// Shift-XOR Reduction for 0x2B.
+    /// 8-wide GF(2^16) flat multiply, bit-identical
+    /// to eight scalar mul_flat_16 calls.
     #[inline(always)]
     pub fn mul_flat_packed_16(lhs: PackedBlock16, rhs: PackedBlock16) -> PackedBlock16 {
-        let r0 = mul_flat_16(lhs.0[0], rhs.0[0]);
-        let r1 = mul_flat_16(lhs.0[1], rhs.0[1]);
-        let r2 = mul_flat_16(lhs.0[2], rhs.0[2]);
-        let r3 = mul_flat_16(lhs.0[3], rhs.0[3]);
-        let r4 = mul_flat_16(lhs.0[4], rhs.0[4]);
-        let r5 = mul_flat_16(lhs.0[5], rhs.0[5]);
-        let r6 = mul_flat_16(lhs.0[6], rhs.0[6]);
-        let r7 = mul_flat_16(lhs.0[7], rhs.0[7]);
+        unsafe {
+            let a = transmute::<[Block16; 8], uint16x8_t>(lhs.0);
+            let b = transmute::<[Block16; 8], uint16x8_t>(rhs.0);
 
-        PackedBlock16([r0, r1, r2, r3, r4, r5, r6, r7])
+            let a_lo = vmovn_u16(a);
+            let a_hi = vmovn_u16(vshrq_n_u16(a, 8));
+            let b_lo = vmovn_u16(b);
+            let b_hi = vmovn_u16(vshrq_n_u16(b, 8));
+
+            let ll = transmute::<poly16x8_t, uint16x8_t>(vmull_p8(
+                transmute::<uint8x8_t, poly8x8_t>(a_lo),
+                transmute::<uint8x8_t, poly8x8_t>(b_lo),
+            ));
+
+            let hh = transmute::<poly16x8_t, uint16x8_t>(vmull_p8(
+                transmute::<uint8x8_t, poly8x8_t>(a_hi),
+                transmute::<uint8x8_t, poly8x8_t>(b_hi),
+            ));
+
+            let mm = transmute::<poly16x8_t, uint16x8_t>(vmull_p8(
+                transmute::<uint8x8_t, poly8x8_t>(veor_u8(a_lo, a_hi)),
+                transmute::<uint8x8_t, poly8x8_t>(veor_u8(b_lo, b_hi)),
+            ));
+
+            PackedBlock16(transmute::<uint16x8_t, [Block16; 8]>(reduce_packed_16(
+                ll, mm, hh,
+            )))
+        }
+    }
+
+    /// Hoists the scalar twiddle's lane-uniform byte split
+    /// out of the eight lanes; otherwise as mul_flat_packed_16.
+    #[inline(always)]
+    pub fn mul_flat_scalar_packed_16(lhs: PackedBlock16, scalar: Block16) -> PackedBlock16 {
+        unsafe {
+            let a = transmute::<[Block16; 8], uint16x8_t>(lhs.0);
+
+            let s_lo = (scalar.0 & 0xff) as u8;
+            let s_hi = (scalar.0 >> 8) as u8;
+
+            let b_lo = transmute::<uint8x8_t, poly8x8_t>(vdup_n_u8(s_lo));
+            let b_hi = transmute::<uint8x8_t, poly8x8_t>(vdup_n_u8(s_hi));
+            let b_mid = transmute::<uint8x8_t, poly8x8_t>(vdup_n_u8(s_lo ^ s_hi));
+
+            let a_lo = vmovn_u16(a);
+            let a_hi = vmovn_u16(vshrq_n_u16(a, 8));
+
+            let ll = transmute::<poly16x8_t, uint16x8_t>(vmull_p8(
+                transmute::<uint8x8_t, poly8x8_t>(a_lo),
+                b_lo,
+            ));
+
+            let hh = transmute::<poly16x8_t, uint16x8_t>(vmull_p8(
+                transmute::<uint8x8_t, poly8x8_t>(a_hi),
+                b_hi,
+            ));
+
+            let mm = transmute::<poly16x8_t, uint16x8_t>(vmull_p8(
+                transmute::<uint8x8_t, poly8x8_t>(veor_u8(a_lo, a_hi)),
+                b_mid,
+            ));
+
+            PackedBlock16(transmute::<uint16x8_t, [Block16; 8]>(reduce_packed_16(
+                ll, mm, hh,
+            )))
+        }
+    }
+
+    // Bit-identical to the scalar mul_flat_16 fold.
+    #[inline(always)]
+    fn reduce_packed_16(ll: uint16x8_t, mm: uint16x8_t, hh: uint16x8_t) -> uint16x8_t {
+        unsafe {
+            let mid = veorq_u16(veorq_u16(mm, ll), hh);
+            let l = veorq_u16(ll, vshlq_n_u16(mid, 8));
+            let h = veorq_u16(hh, vshrq_n_u16(mid, 8));
+
+            let h_fold = veorq_u16(
+                veorq_u16(vshlq_n_u16(h, 5), vshlq_n_u16(h, 3)),
+                veorq_u16(vshlq_n_u16(h, 1), h),
+            );
+
+            // h <= deg 14, so h*R spills <= 4 bits past bit 15.
+            let carry = veorq_u16(
+                veorq_u16(vshrq_n_u16(h, 11), vshrq_n_u16(h, 13)),
+                vshrq_n_u16(h, 15),
+            );
+
+            let carry_fold = veorq_u16(
+                veorq_u16(vshlq_n_u16(carry, 5), vshlq_n_u16(carry, 3)),
+                veorq_u16(vshlq_n_u16(carry, 1), carry),
+            );
+
+            veorq_u16(veorq_u16(l, h_fold), carry_fold)
+        }
     }
 }
 
@@ -637,6 +766,9 @@ mod neon {
 mod tests {
     use super::*;
     use rand::{RngExt, rng};
+
+    #[cfg(target_arch = "aarch64")]
+    use proptest::prelude::*;
 
     // ==================================
     // BASIC
@@ -976,6 +1108,36 @@ mod tests {
                     "Block16 tower_bit_from_hardware mismatch at x_flat={x_flat:#06x}, bit_idx={k}"
                 );
             }
+        }
+    }
+
+    // The NEON vmull_p8 path vs
+    // the scalar vmull_p64 path.
+    #[cfg(target_arch = "aarch64")]
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(65536))]
+
+        #[test]
+        fn neon_packed_eq_scalar(a in any::<[u16; 8]>(), b in any::<[u16; 8]>()) {
+            let pp = neon::mul_flat_packed_16(
+                PackedBlock16(a.map(Block16)),
+                PackedBlock16(b.map(Block16)),
+            );
+
+            let want: [Block16; 8] =
+                core::array::from_fn(|i| neon::mul_flat_16(Block16(a[i]), Block16(b[i])));
+
+            prop_assert_eq!(pp.0, want);
+        }
+
+        #[test]
+        fn neon_scalar_packed_eq_scalar(a in any::<[u16; 8]>(), s in any::<u16>()) {
+            let sp = neon::mul_flat_scalar_packed_16(PackedBlock16(a.map(Block16)), Block16(s));
+
+            let want: [Block16; 8] =
+                core::array::from_fn(|i| neon::mul_flat_16(Block16(a[i]), Block16(s)));
+
+            prop_assert_eq!(sp.0, want);
         }
     }
 }

--- a/src/towers/block8.rs
+++ b/src/towers/block8.rs
@@ -67,6 +67,23 @@ impl Block8 {
     pub const fn new(val: u8) -> Self {
         Self(val)
     }
+
+    #[inline(always)]
+    pub fn square(self) -> Self {
+        // Carryless square (bit spread), then fold the
+        // high half twice by 0x1b (= x^4 + x^3 + x + 1).
+        let mut s = self.0 as u16;
+        s = (s | (s << 4)) & 0x0f0f;
+        s = (s | (s << 2)) & 0x3333;
+        s = (s | (s << 1)) & 0x5555;
+
+        let hi = s >> 8;
+        let s = (s & 0x00ff) ^ (hi ^ (hi << 1) ^ (hi << 3) ^ (hi << 4));
+
+        let hi = s >> 8;
+
+        Block8(((s & 0x00ff) ^ (hi ^ (hi << 1) ^ (hi << 3) ^ (hi << 4))) as u8)
+    }
 }
 
 impl TowerField for Block8 {
@@ -838,6 +855,14 @@ mod tests {
         // Example from the AES specification:
         // 0x57 * 0x83 = 0xC1
         assert_eq!(Block8(0x57) * Block8(0x83), Block8(0xC1));
+    }
+
+    #[test]
+    fn square_exhaustive() {
+        for i in 0u16..=255 {
+            let x = Block8(i as u8);
+            assert_eq!(x.square(), x * x, "Block8 square mismatch at {i:#04x}");
+        }
     }
 
     #[test]

--- a/tests/algebra.rs
+++ b/tests/algebra.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the hekate-math project.
+// Copyright (C) 2026 Andrei Kochergin <andrei@oumuamua.dev>
+// Copyright (C) 2026 Oumuamua Labs <info@oumuamua.dev>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use hekate_math::{BinaryFieldExtras, Bit, Block16, TowerField};
+
+// Independent trace oracle:
+// the squaring-chain definition.
+fn trace_via_squaring<F: BinaryFieldExtras>(x: F) -> Bit {
+    let mut acc = F::ZERO;
+    let mut p = x;
+
+    for _ in 0..F::BITS {
+        acc += p;
+        p = p.square();
+    }
+
+    Bit((acc == F::ONE) as u8)
+}
+
+#[test]
+fn block16_square_eq_mul() {
+    for v in 0u16..=u16::MAX {
+        let x = Block16(v);
+        assert_eq!(x.square(), x * x, "square != mul at {v:#06x}");
+    }
+}
+
+#[test]
+fn block16_square_eq_frobenius() {
+    for v in 0u16..=u16::MAX {
+        let x = Block16(v);
+        assert_eq!(
+            x.square(),
+            x.frobenius(1),
+            "square != frobenius(1) at {v:#06x}"
+        );
+    }
+}
+
+#[test]
+fn block16_frobenius_periodicity() {
+    for v in 0u16..=u16::MAX {
+        let x = Block16(v);
+
+        assert_eq!(x.frobenius(0), x);
+        assert_eq!(x.frobenius(16), x);
+        assert_eq!(x.frobenius(17), x.square());
+
+        let mut p = x;
+        for _ in 0..16 {
+            p = p.square();
+        }
+
+        assert_eq!(p, x, "16-fold square must be identity at {v:#06x}");
+    }
+}
+
+#[test]
+fn block16_frobenius_homomorphism() {
+    for a in (0u16..=u16::MAX).step_by(37) {
+        for b in (0u16..=u16::MAX).step_by(149) {
+            let x = Block16(a);
+            let y = Block16(b);
+
+            assert_eq!((x + y).frobenius(3), x.frobenius(3) + y.frobenius(3));
+            assert_eq!((x * y).frobenius(3), x.frobenius(3) * y.frobenius(3));
+        }
+    }
+}
+
+#[test]
+fn block16_trace_in_gf2_and_additive() {
+    for v in 0u16..=u16::MAX {
+        let t = Block16(v).trace();
+        assert!(
+            t == Bit(0) || t == Bit(1),
+            "trace escaped GF(2) at {v:#06x}"
+        );
+    }
+
+    for a in (0u16..=u16::MAX).step_by(29) {
+        for b in (0u16..=u16::MAX).step_by(127) {
+            let x = Block16(a);
+            let y = Block16(b);
+
+            assert_eq!((x + y).trace(), Bit(x.trace().0 ^ y.trace().0));
+        }
+    }
+}
+
+#[test]
+fn block16_trace_frobenius_invariant() {
+    for v in 0u16..=u16::MAX {
+        let x = Block16(v);
+        assert_eq!(
+            x.square().trace(),
+            x.trace(),
+            "Tr(x^2) != Tr(x) at {v:#06x}"
+        );
+    }
+
+    assert_eq!(
+        Block16::ONE.trace(),
+        Bit(0),
+        "Tr(1) must vanish for GF(2^16)"
+    );
+}
+
+#[test]
+fn block16_trace_mask_eq_squaring_chain() {
+    for v in 0u16..=u16::MAX {
+        let x = Block16(v);
+        assert_eq!(
+            x.trace(),
+            trace_via_squaring(x),
+            "trace mismatch at {v:#06x}"
+        );
+    }
+}
+
+#[test]
+fn block16_solve_quadratic_roundtrip() {
+    for v in 0u16..=u16::MAX {
+        let c = Block16(v);
+        match Block16::solve_quadratic(c) {
+            Some(r) => {
+                assert_eq!(r * r + r, c, "root invalid at {v:#06x}");
+
+                let other = r + Block16::ONE;
+                assert_eq!(other * other + other, c, "second root invalid at {v:#06x}");
+                assert_eq!(c.trace(), Bit(0), "solved c with Tr != 0 at {v:#06x}");
+            }
+            None => assert_eq!(c.trace(), Bit(1), "rejected solvable c at {v:#06x}"),
+        }
+    }
+}
+
+#[test]
+fn block16_solve_quadratic_iff_trace_zero() {
+    let mut solvable = 0u32;
+    for v in 0u16..=u16::MAX {
+        let c = Block16(v);
+        let ok = Block16::solve_quadratic(c).is_some();
+
+        assert_eq!(
+            ok,
+            c.trace() == Bit(0),
+            "solvability != (Tr == 0) at {v:#06x}"
+        );
+
+        if ok {
+            solvable += 1;
+        }
+    }
+
+    assert_eq!(solvable, 32768, "exactly half of GF(2^16) must be solvable");
+}

--- a/tests/fft.rs
+++ b/tests/fft.rs
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of the hekate-math project.
+// Copyright (C) 2026 Andrei Kochergin <andrei@oumuamua.dev>
+// Copyright (C) 2026 Oumuamua Labs <info@oumuamua.dev>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use hekate_math::fft::vanish_eval;
+use hekate_math::{
+    AdditiveFft, BinaryFieldExtras, Block16, CantorBasis, FftError, Flat, HardwareField,
+    PackableField, PackedFlat, TowerField,
+};
+use rand::{RngExt, rng};
+
+fn eval_point(j: usize) -> Block16 {
+    let mut acc = Block16::ZERO;
+    let mut bits = j;
+
+    while bits != 0 {
+        let i = bits.trailing_zeros() as usize;
+        acc += CantorBasis::beta_tower(i);
+        bits &= bits - 1;
+    }
+
+    acc
+}
+
+// Independent O(n^2) oracle:
+// f(x) = Σ a_t X_t(x),
+// X_t = ∏_{bit i of t} s_i,
+// s_i the i-fold σ(t)=t^2+t.
+fn horner_eval(coeffs: &[Block16], x: Block16, log_n: u32) -> Block16 {
+    let mut s = [Block16::ZERO; 16];
+    s[0] = x;
+
+    for i in 1..log_n as usize {
+        s[i] = s[i - 1].square() + s[i - 1];
+    }
+
+    let mut acc = Block16::ZERO;
+
+    for (t, &a) in coeffs.iter().enumerate() {
+        let mut xt = Block16::ONE;
+        let mut bits = t;
+
+        while bits != 0 {
+            let i = bits.trailing_zeros() as usize;
+            xt *= s[i];
+            bits &= bits - 1;
+        }
+
+        acc += a * xt;
+    }
+
+    acc
+}
+
+#[test]
+fn cantor_self_check() {
+    assert!(CantorBasis::self_check());
+}
+
+#[test]
+fn vanish_eval_linearity_and_recurrence() {
+    let mut r = rng();
+
+    for i in 0..=16usize {
+        for _ in 0..256 {
+            let u = Block16(r.random());
+            let v = Block16(r.random());
+
+            assert_eq!(
+                vanish_eval(i, u + v),
+                vanish_eval(i, u) + vanish_eval(i, v),
+                "vanish_eval not GF(2)-linear at i={i}"
+            );
+
+            if i >= 1 {
+                let prev = vanish_eval(i - 1, u);
+                assert_eq!(
+                    vanish_eval(i, u),
+                    prev.square() + prev,
+                    "s_i recurrence at i={i}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn additive_fft_eq_horner() {
+    let log_n = 8u32;
+    let n = 1usize << log_n;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
+    let mut r = rng();
+
+    let coeffs: Vec<Block16> = (0..n).map(|_| Block16(r.random())).collect();
+
+    let mut data: Vec<Flat<Block16>> = coeffs.iter().map(|c| c.to_hardware()).collect();
+    fft.forward_scalar(&mut data).unwrap();
+
+    for (j, slot) in data.iter().enumerate() {
+        let expected = horner_eval(&coeffs, eval_point(j), log_n);
+        assert_eq!(slot.to_tower(), expected, "FFT != Horner at j={j}");
+    }
+}
+
+#[test]
+fn additive_fft_roundtrip_scalar() {
+    let log_n = 10u32;
+    let n = 1usize << log_n;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
+    let mut r = rng();
+
+    let orig: Vec<Flat<Block16>> = (0..n)
+        .map(|_| Flat::from_raw(Block16(r.random())))
+        .collect();
+
+    let mut data = orig.clone();
+    fft.forward_scalar(&mut data).unwrap();
+    fft.inverse_scalar(&mut data).unwrap();
+
+    assert_eq!(data, orig, "inverse∘forward != id");
+
+    let mut data2 = orig.clone();
+    fft.inverse_scalar(&mut data2).unwrap();
+    fft.forward_scalar(&mut data2).unwrap();
+
+    assert_eq!(data2, orig, "forward∘inverse != id");
+}
+
+#[test]
+fn additive_fft_roundtrip_packed() {
+    let log_n = 9u32;
+    let n = 1usize << log_n;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
+    let mut r = rng();
+
+    let orig: Vec<PackedFlat<Block16>> = (0..n)
+        .map(|_| {
+            let lanes: [Flat<Block16>; 8] =
+                core::array::from_fn(|_| Flat::from_raw(Block16(r.random())));
+            <Flat<Block16> as PackableField>::pack(&lanes)
+        })
+        .collect();
+
+    let mut data = orig.clone();
+    fft.forward(&mut data).unwrap();
+    fft.inverse(&mut data).unwrap();
+
+    assert_eq!(data, orig, "packed inverse∘forward != id");
+}
+
+#[test]
+fn additive_fft_packed_eq_scalar() {
+    let log_n = 6u32;
+    let n = 1usize << log_n;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
+    let mut r = rng();
+
+    let mut cols: Vec<Vec<Flat<Block16>>> = (0..8)
+        .map(|_| {
+            (0..n)
+                .map(|_| Flat::from_raw(Block16(r.random())))
+                .collect()
+        })
+        .collect();
+
+    let mut packed: Vec<PackedFlat<Block16>> = (0..n)
+        .map(|k| {
+            let lanes: [Flat<Block16>; 8] = core::array::from_fn(|l| cols[l][k]);
+            <Flat<Block16> as PackableField>::pack(&lanes)
+        })
+        .collect();
+
+    fft.forward(&mut packed).unwrap();
+
+    for col in cols.iter_mut() {
+        fft.forward_scalar(col).unwrap();
+    }
+
+    for (k, pk) in packed.iter().enumerate() {
+        let mut out = [Flat::<Block16>::default(); 8];
+        <Flat<Block16> as PackableField>::unpack(*pk, &mut out);
+
+        for (l, lane) in out.iter().enumerate() {
+            assert_eq!(*lane, cols[l][k], "packed != scalar at k={k}, lane={l}");
+        }
+    }
+}
+
+#[test]
+fn additive_fft_coset_eq_horner() {
+    let log_n = 7u32;
+    let n = 1usize << log_n;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
+    let mut r = rng();
+
+    let offset = Block16(r.random());
+    let coeffs: Vec<Block16> = (0..n).map(|_| Block16(r.random())).collect();
+
+    let mut data: Vec<Flat<Block16>> = coeffs.iter().map(|c| c.to_hardware()).collect();
+    fft.forward_coset_scalar(&mut data, offset.to_hardware())
+        .unwrap();
+
+    for (j, slot) in data.iter().enumerate() {
+        let expected = horner_eval(&coeffs, offset + eval_point(j), log_n);
+        assert_eq!(slot.to_tower(), expected, "coset FFT != Horner at j={j}");
+    }
+}
+
+#[test]
+fn additive_fft_deterministic() {
+    let log_n = 9u32;
+    let n = 1usize << log_n;
+
+    let mut r = rng();
+
+    let input: Vec<Flat<Block16>> = (0..n)
+        .map(|_| Flat::from_raw(Block16(r.random())))
+        .collect();
+
+    let fft1 = AdditiveFft::<Block16>::new(log_n);
+    let fft2 = AdditiveFft::<Block16>::new(log_n);
+
+    let mut a = input.clone();
+    let mut b = input.clone();
+
+    fft1.forward_scalar(&mut a).unwrap();
+    fft2.forward_scalar(&mut b).unwrap();
+
+    assert_eq!(a, b, "forward not deterministic across instances");
+}
+
+#[test]
+fn additive_fft_rejects_bad_length() {
+    let fft = AdditiveFft::<Block16>::new(8);
+    let mut data = vec![Flat::from_raw(Block16::ZERO); 100];
+
+    assert!(matches!(
+        fft.forward_scalar(&mut data),
+        Err(FftError::BadLength { .. })
+    ));
+}
+
+#[test]
+fn additive_fft_coset_roundtrip_scalar() {
+    let log_n = 8u32;
+    let n = 1usize << log_n;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
+    let mut r = rng();
+
+    let offset = Flat::from_raw(Block16(r.random()));
+    let orig: Vec<Flat<Block16>> = (0..n)
+        .map(|_| Flat::from_raw(Block16(r.random())))
+        .collect();
+
+    let mut data = orig.clone();
+    fft.forward_coset_scalar(&mut data, offset).unwrap();
+    fft.inverse_coset_scalar(&mut data, offset).unwrap();
+
+    assert_eq!(data, orig, "coset inverse∘forward != id");
+
+    let mut data2 = orig.clone();
+    fft.inverse_coset_scalar(&mut data2, offset).unwrap();
+    fft.forward_coset_scalar(&mut data2, offset).unwrap();
+
+    assert_eq!(data2, orig, "coset forward∘inverse != id");
+}
+
+#[test]
+fn additive_fft_coset_packed_eq_scalar() {
+    let log_n = 6u32;
+    let n = 1usize << log_n;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
+    let mut r = rng();
+
+    let offset = Flat::from_raw(Block16(r.random()));
+
+    let cols: Vec<Vec<Flat<Block16>>> = (0..8)
+        .map(|_| {
+            (0..n)
+                .map(|_| Flat::from_raw(Block16(r.random())))
+                .collect()
+        })
+        .collect();
+
+    let mut packed: Vec<PackedFlat<Block16>> = (0..n)
+        .map(|k| {
+            let lanes: [Flat<Block16>; 8] = core::array::from_fn(|l| cols[l][k]);
+            <Flat<Block16> as PackableField>::pack(&lanes)
+        })
+        .collect();
+
+    let orig_packed = packed.clone();
+
+    fft.forward_coset(&mut packed, offset).unwrap();
+
+    let mut cols_fwd = cols.clone();
+    for col in cols_fwd.iter_mut() {
+        fft.forward_coset_scalar(col, offset).unwrap();
+    }
+
+    for (k, pk) in packed.iter().enumerate() {
+        let mut out = [Flat::<Block16>::default(); 8];
+        <Flat<Block16> as PackableField>::unpack(*pk, &mut out);
+
+        for (l, lane) in out.iter().enumerate() {
+            assert_eq!(
+                *lane, cols_fwd[l][k],
+                "packed coset != scalar coset at k={k}, lane={l}"
+            );
+        }
+    }
+
+    fft.inverse_coset(&mut packed, offset).unwrap();
+
+    assert_eq!(packed, orig_packed, "packed coset inverse∘forward != id");
+}
+
+// log_n = 1:
+// recursion base case and
+// the empty-lift path in new().
+#[test]
+fn additive_fft_eq_horner_min() {
+    let log_n = 1u32;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
+    let mut r = rng();
+
+    let coeffs: Vec<Block16> = (0..2).map(|_| Block16(r.random())).collect();
+
+    let mut data: Vec<Flat<Block16>> = coeffs.iter().map(|c| c.to_hardware()).collect();
+    fft.forward_scalar(&mut data).unwrap();
+
+    for (j, slot) in data.iter().enumerate() {
+        let expected = horner_eval(&coeffs, eval_point(j), log_n);
+        assert_eq!(slot.to_tower(), expected, "min FFT != Horner at j={j}");
+    }
+}
+
+// log_n = F::BITS:
+// full Cantor basis, deepest recursion,
+// and the only size that derives β_15
+// (the lone Tr = 1 element) in new().
+#[test]
+fn additive_fft_roundtrip_field_max() {
+    let log_n = Block16::BITS as u32;
+    let n = 1usize << log_n;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
+    let mut r = rng();
+
+    let orig: Vec<Flat<Block16>> = (0..n)
+        .map(|_| Flat::from_raw(Block16(r.random())))
+        .collect();
+
+    let mut data = orig.clone();
+    fft.forward_scalar(&mut data).unwrap();
+    fft.inverse_scalar(&mut data).unwrap();
+
+    assert_eq!(data, orig, "field-max inverse∘forward != id");
+}
+
+#[test]
+fn additive_fft_roundtrip_field_max_packed() {
+    let log_n = Block16::BITS as u32;
+    let n = 1usize << log_n;
+    let fft = AdditiveFft::<Block16>::new(log_n);
+
+    let mut r = rng();
+
+    let orig: Vec<PackedFlat<Block16>> = (0..n)
+        .map(|_| {
+            let lanes: [Flat<Block16>; 8] =
+                core::array::from_fn(|_| Flat::from_raw(Block16(r.random())));
+            <Flat<Block16> as PackableField>::pack(&lanes)
+        })
+        .collect();
+
+    let mut data = orig.clone();
+    fft.forward(&mut data).unwrap();
+    fft.inverse(&mut data).unwrap();
+
+    assert_eq!(data, orig, "field-max packed inverse∘forward != id");
+}
+
+#[test]
+#[should_panic(expected = "log_n must be in")]
+fn additive_fft_new_rejects_zero() {
+    let _ = AdditiveFft::<Block16>::new(0);
+}
+
+#[test]
+#[should_panic(expected = "log_n must be in")]
+fn additive_fft_new_rejects_above_field_bits() {
+    let _ = AdditiveFft::<Block16>::new(Block16::BITS as u32 + 1);
+}
+
+#[test]
+#[should_panic]
+fn cantor_beta_tower_out_of_range_panics() {
+    let _ = CantorBasis::beta_tower(CantorBasis::DIM);
+}
+
+#[test]
+fn fft_error_display_carries_lengths() {
+    let fft = AdditiveFft::<Block16>::new(8);
+    let mut data = vec![Flat::from_raw(Block16::ZERO); 7];
+
+    let err = fft.forward_scalar(&mut data).unwrap_err();
+    assert_eq!(
+        err,
+        FftError::BadLength {
+            expected: 256,
+            got: 7,
+        }
+    );
+
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("256") && msg.contains('7'),
+        "uninformative: {msg}"
+    );
+}


### PR DESCRIPTION
Adds an in-place additive NTT for GF(2^16) on the Cantor basis, the binary-field algebra it stands on (Frobenius, absolute trace, Artin–Schreier solver), and a vectorized NEON packed multiply for Block16. Additive and self-contained: new public modules (`fft`, `algebra`) and methods only, no existing signature changes, no change to tower/flat arithmetic results, every existing field operation byte-for-byte unaffected. The generated GF(2^16) constants are pinned at build time against the canonical change-of-basis matrices (AES known-answer test plus a change-of-basis squaring oracle over all 65536 elements), a wrong reduction polynomial or extension τ fails the build, not a downstream proof. aarch64, `--release`:

| Transform             | Size              | Latency | Throughput  |
|:----------------------|:------------------|--------:|:------------|
| Additive FFT (scalar) | 2¹⁶ pts · Block16  | 1.31 ms | 50 Melem/s  |
| Additive FFT (packed) | 2¹⁶ pts · ×8 lanes | 3.16 ms | 166 Melem/s |

## Changes

### Generate GF(2^16) trace, Artin–Schreier, and Cantor constants

Emits `TRACE_MASK_16` (trace as a parity mask), `SOLVE_QUADRATIC_BASIS_16` (the GF(2)-linear operator solving `x² + x = c`), and `CANTOR_BASIS_TOWER_16` (β₀ = 1, βᵢ₋₁ = βᵢ² + βᵢ). The solver lifts the singular `L(x) = x² + x` (kernel {0,1}) to an invertible `L̃` by mapping e₀ to a trace-one vector, then inverts; `L̃⁻¹` on the trace-zero subspace returns the bit0 = 0 root.

The load-bearing addition is build-time pinning of the field model to the canonical, independently hardcoded `FLAT_TO_TOWER_16` / `TOWER_TO_FLAT_16` matrices. `POLY_8`, `POLY_16`, and `EXTENSION_TAU_8` are now named constants: `POLY_8`/`POLY_16` are emitted verbatim as `constants::POLY_8`/`POLY_16` from the same source, so the build model and the crate constants cannot diverge. Two assertions run during compilation: an AES known-answer test (`gf8_mul(0x57,0x83) == 0xc1`, FIPS-197 §4.2) pins `POLY_8`, and a change-of-basis squaring oracle (`sq16_tower(x)` vs squaring routed through the matrices) pins the triple to the matrices over all 65536 elements. Previously a wrong τ would still produce a self-consistent field and pass the existing self-checks, surfacing only as a runtime test failure; it now fails the build.

### Add BinaryFieldExtras trait

Binary-field operations beyond core `TowerField`: `frobenius(k)` (`x^(2^k)`, k taken mod the field degree), absolute trace (`Σ x^(2^i)`, always 0 or 1), and `solve_quadratic(c)`, a root of `x² + x = c`, or `None` iff `Tr(c) ≠ 0`. The value path is constant-time; only the `Some`/`None` choice reveals `Tr(c)`, and in the FFT it is invoked solely on public Cantor-basis elements during setup.

### Binary-field squaring, Block16 algebra, NEON packed multiply

`Block8::square` is a constant-time carryless square (bit-spread, then fold the high half twice by 0x1b), verified exhaustively against `x * x`. `Block16` implements `BinaryFieldExtras`: squaring via `(lo + hi·X)² = lo² + hi²·X²` with no cross term, trace via `TRACE_MASK_16`, and `solve_quadratic` via the constant-time `map_ct_16` over `SOLVE_QUADRATIC_BASIS_16`.

The packed `mul_flat_packed_16` replaces eight scalar `mul_flat_16` calls with a single 8-wide `vmull_p8` Karatsuba decomposition and a two-step shift-XOR fold for `R = 0x2b`; `mul_flat_scalar_packed_16` hoists the twiddle's lane-uniform byte split for the FFT's scalar-by-vector multiply. Both are proptested bit-identical to the scalar path (65536 cases each). `map_ct_16` loses its `table-math` cfg-gate because `solve_quadratic` needs it in every configuration, it remains the constant-time path even under `table-math` the solver never touches a lookup table.

### Additive FFT over GF(2^16) (Gao–Mateer, Cantor basis)

`AdditiveFft<F>` provides in-place scalar and packed forward/inverse transforms, each with a coset variant. `new(log_n)` derives the Cantor basis via `solve_quadratic` and precomputes the twiddle schedule, the only heap allocation; transforms are in place. Butterflies run in the flat (hardware) basis: the child coset `coset² + coset` is the Frobenius computed flat, valid because add and mul are homomorphic across the tower↔flat isomorphism. `CantorBasis` is a typed view over the baked basis with a `self_check` against live arithmetic, and `vanish_eval` evaluates the subspace vanishing polynomials. `lib.rs` exposes the `fft` and `algebra` modules and re-exports their public surface.

### FFT benchmark, README metrics, gitignore

Replaces the previous mock-butterfly FFT benchmark with the real Gao–Mateer transform (profile and field-max sizes), refreshes the README performance table, and ignores `.claude`.

## Compatibility

- Purely additive public API: new `algebra::BinaryFieldExtras`, `fft::{AdditiveFft, CantorBasis, FftError, vanish_eval}`, and `Block8::square`. No existing signature changed.
- `map_ct_16` is now compiled in all feature configurations (was `table-math`-gated); basis-conversion behavior is unchanged.
- No change to serialized forms, tower/flat arithmetic results, or the generated constants for any existing block size. `AdditiveFft` is generic but instantiable only where `BinaryFieldExtras` is implemented (currently Block16).

## Out of scope

Only Block16 implements `BinaryFieldExtras`, the FFT is currently GF(2^16) only. Larger tower fields (Block32 and up) and an x86_64 PCLMULQDQ packed multiply path are separate work.
